### PR TITLE
Add diff command + telophase calls

### DIFF
--- a/cmd/auth.go
+++ b/cmd/auth.go
@@ -39,7 +39,7 @@ var authCommand = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		if args[0] == "signup" {
 			if err := openSignup(); err != nil {
-				panic(fmt.Sprintf("error opening signup page: %s. Please visit https://app.telophade.dev", err))
+				panic(fmt.Sprintf("error opening signup page: %s. Please visit https://app.telophase.dev", err))
 			}
 		}
 	},

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,9 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	if os.Getenv("TELOPHASE_TOKEN") == "" && os.Getenv("TELOPHASE_TOKEN") != "ignore" {
+		fmt.Println("(Optional) Signup for Telophase for an even better experience! https://app.telophase.dev. Set TELOPHASE_TOKEN=ignore in your env to hide this message.")
+	}
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Whoops. There was an error while executing your CLI '%s'", err)
 		os.Exit(1)

--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/santiago-labs/telophasecli/lib/telophase"
 )
 
 type Client struct {
@@ -102,6 +103,7 @@ func (c Client) CreateAccounts(ctx context.Context, accts []*organizations.Accou
 			case "SUCCEEDED":
 				fmt.Printf("Successfully created account %s.\n", accountName)
 				requestsInProgress -= 1
+				telophase.UpsertAccount(*currStatus.CreateAccountStatus.AccountId, accountName)
 			}
 		}
 	}


### PR DESCRIPTION
1) Add diff command. The `deploy` command relied on `--require-approval` to show output for a deploy without applying the changes. This flag is for security changes https://docs.aws.amazon.com/cdk/v2/guide/cli.html. I introduced the `diff` command to follow CDK pattern
2) Make backend calls to Telophase if the user has a telophase api key in their env