### PR TITLE
Associate accounts with Stacks to apply

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,10 +1,8 @@
 package cmd
 
 import (
-	"fmt"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 
 	"github.com/santiago-labs/telophasecli/lib/awssts"
@@ -37,8 +35,8 @@ var diffCmd = &cobra.Command{
 type diffIAC struct{}
 
 func (d diffIAC) cdkCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, cdkPath string) *exec.Cmd {
-	tmpPath := path.Join("telophasedirs", fmt.Sprintf("cdk-tmp%s", acct.AccountID))
-	cdkArgs := []string{"diff", "--output", tmpPath}
+	outPath := tmpPath("CDK", acct, cdkPath)
+	cdkArgs := []string{"diff", "--output", outPath}
 	if stacks != "" {
 		cdkArgs = append(cdkArgs, strings.Split(stacks, ",")...)
 	}
@@ -53,12 +51,12 @@ func (d diffIAC) cdkCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, cd
 }
 
 func (d diffIAC) tfCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, tfPath string) *exec.Cmd {
-	tmpPath := path.Join("telophasedirs", fmt.Sprintf("tf-tmp%s", acct.AccountID))
+	workingPath := tmpPath("Terraform", acct, tfPath)
 	args := []string{
 		"plan",
 	}
 	cmd := exec.Command("terraform", args...)
-	cmd.Dir = tmpPath
+	cmd.Dir = workingPath
 	cmd.Env = awssts.SetEnviron(os.Environ(),
 		*result.Credentials.AccessKeyId,
 		*result.Credentials.SecretAccessKey,

--- a/lib/ymlparser/organization.go
+++ b/lib/ymlparser/organization.go
@@ -29,6 +29,13 @@ type Account struct {
 	AccountID      string   `yaml:"AccountID,omitempty"`
 	AssumeRoleName string   `yaml:"AssumeRoleName,omitempty"`
 	Tags           []string `yaml:"Tags,omitempty"`
+	Stacks         []Stack  `yaml:"Stacks,omitempty"`
+}
+
+type Stack struct {
+	Name string `yaml:"Name"`
+	Type string `yaml:"Type"`
+	Path string `yaml:"Path"`
 }
 
 func (a Account) AssumeRoleARN() string {
@@ -48,7 +55,6 @@ func ParseOrganization(filepath string) (Organization, error) {
 
 	data, err := ioutil.ReadFile(filepath)
 	if err != nil {
-		fmt.Println("read file")
 		return Organization{}, fmt.Errorf("err: %s reading file %s", err.Error(), filepath)
 	}
 


### PR DESCRIPTION
This feature allows you to specify stacks for each account in organization.yml.

Benefits:
1. Apply multiple TF or CDK stacks to each account in a single cli run.
2. Stack <-> Account association in version control.