### PR TITLE
use diff/deploy for account provisioning

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -83,7 +83,7 @@ func (d deployIAC) tfCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, s
 }
 
 func (d deployIAC) orgV1Cmd(ctx context.Context, orgClient awsorgs.Client) {
-	newAccounts, _, err := orgV1Plan(orgClient)
+	newAccounts, _, err := orgV1Diff(orgClient)
 	if err != nil {
 		panic(fmt.Sprintf("error: %s", err))
 	}
@@ -95,7 +95,7 @@ func (d deployIAC) orgV1Cmd(ctx context.Context, orgClient awsorgs.Client) {
 }
 
 func (d deployIAC) orgV2Cmd(ctx context.Context, orgClient awsorgs.Client) {
-	ops, err := orgV2Plan(orgClient)
+	ops, err := orgV2Diff(orgClient)
 	if err != nil {
 		panic(fmt.Sprintf("error: %s", err))
 	}

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -69,14 +69,14 @@ func (d diffIAC) tfCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, sta
 }
 
 func (d diffIAC) orgV1Cmd(ctx context.Context, orgClient awsorgs.Client) {
-	_, _, err := orgV1Plan(orgClient)
+	_, _, err := orgV1Diff(orgClient)
 	if err != nil {
 		panic(fmt.Sprintf("error: %s", err))
 	}
 }
 
 func (d diffIAC) orgV2Cmd(ctx context.Context, orgClient awsorgs.Client) {
-	_, err := orgV2Plan(orgClient)
+	_, err := orgV2Diff(orgClient)
 	if err != nil {
 		panic(fmt.Sprintf("error: %s", err))
 	}

--- a/cmd/provisionaccounts.go
+++ b/cmd/provisionaccounts.go
@@ -31,9 +31,9 @@ func isValidAccountArg(arg string) bool {
 	switch arg {
 	case "import":
 		return true
-	case "plan":
+	case "diff":
 		return true
-	case "apply":
+	case "deploy":
 		return true
 	default:
 		return false
@@ -67,23 +67,23 @@ var accountProvision = &cobra.Command{
 			}
 		}
 
-		if args[0] == "plan" {
+		if args[0] == "diff" {
 			if ymlparser.IsUsingOrgV1(orgFile) {
-				_, _, err := orgV1Plan(orgClient)
+				_, _, err := orgV1Diff(orgClient)
 				if err != nil {
 					panic(fmt.Sprintf("error: %s", err))
 				}
 			} else {
-				_, err := orgV2Plan(orgClient)
+				_, err := orgV2Diff(orgClient)
 				if err != nil {
 					panic(fmt.Sprintf("error: %s", err))
 				}
 			}
 		}
 
-		if args[0] == "apply" {
+		if args[0] == "deploy" {
 			if ymlparser.IsUsingOrgV1(orgFile) {
-				newAccounts, _, err := orgV1Plan(orgClient)
+				newAccounts, _, err := orgV1Diff(orgClient)
 				if err != nil {
 					panic(fmt.Sprintf("error: %s", err))
 				}
@@ -93,7 +93,7 @@ var accountProvision = &cobra.Command{
 					panic(fmt.Sprintf("error creating accounts %v", errs))
 				}
 			} else {
-				operations, err := orgV2Plan(orgClient)
+				operations, err := orgV2Diff(orgClient)
 				if err != nil {
 					panic(fmt.Sprintf("error: %s", err))
 				}
@@ -109,7 +109,7 @@ var accountProvision = &cobra.Command{
 	},
 }
 
-func orgV1Plan(orgClient awsorgs.Client) (new []*organizations.Account, toDelete []*organizations.Account, err error) {
+func orgV1Diff(orgClient awsorgs.Client) (new []*organizations.Account, toDelete []*organizations.Account, err error) {
 	org, err := ymlparser.ParseOrganizationV1(orgFile)
 	if err != nil {
 		panic(fmt.Sprintf("error: %s parsing organization", err))
@@ -185,7 +185,7 @@ func orgV1Plan(orgClient awsorgs.Client) (new []*organizations.Account, toDelete
 	return newAccounts, deletedAccounts, nil
 }
 
-func orgV2Plan(orgClient awsorgs.Client) (ops []ymlparser.ResourceOperation, err error) {
+func orgV2Diff(orgClient awsorgs.Client) (ops []ymlparser.ResourceOperation, err error) {
 	org, err := ymlparser.ParseOrganizationV2(orgFile)
 	if err != nil {
 		panic(fmt.Sprintf("error: %s parsing organization", err))

--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -174,6 +174,16 @@ func (c Client) RecreateOU(ctx context.Context, ouID, ouName, newParentId string
 	return nil
 }
 
+func (c Client) UpdateOrganizationUnit(ctx context.Context, ouID, newName string) error {
+	_, err := c.organizationClient.UpdateOrganizationalUnitWithContext(ctx,
+		&organizations.UpdateOrganizationalUnitInput{
+			Name:                 aws.String(newName),
+			OrganizationalUnitId: aws.String(ouID),
+		})
+
+	return err
+}
+
 func (c Client) CreateAccounts(ctx context.Context, accts []*organizations.Account) []error {
 	var errs []error
 	var createRequests []*organizations.CreateAccountStatus

--- a/lib/ymlparser/organizationv2.go
+++ b/lib/ymlparser/organizationv2.go
@@ -101,7 +101,6 @@ func (grp AccountGroup) Diff(orgClient awsorgs.Client) []ResourceOperation {
 		}
 
 		if !found {
-			fmt.Printf("%v\n", parsedGroup)
 			if parsedGroup.Parent.ID == nil {
 				for _, newGroup := range FlattenOperations(operations) {
 					newGroupOperation, ok := newGroup.(*OrganizationUnitOperation)


### PR DESCRIPTION
CDK/TF used `diff` and `deploy` commands. Account provisoning uses `plan` and `apply` commands. This is confusing. We're focusing on CDK support for now, so let's standardize on CDK commands