### PR TITLE
Ethan/output passing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,11 +19,12 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
-	github.com/aws/aws-sdk-go-v2 v1.21.2 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43 // indirect
-	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37 // indirect
+	github.com/aws/aws-sdk-go-v2 v1.24.0 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9 // indirect
+	github.com/aws/aws-sdk-go-v2/service/cloudformation v1.42.3 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.37 // indirect
-	github.com/aws/smithy-go v1.15.0 // indirect
+	github.com/aws/smithy-go v1.19.0 // indirect
 	github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.200 // indirect
 	github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.2 // indirect
 	github.com/cdklabs/awscdk-asset-node-proxy-agent-go/nodeproxyagentv6/v2 v2.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,10 +11,18 @@ github.com/aws/aws-sdk-go v1.46.0 h1:Igh7W8P+sA6mXJ9yhreOSweefLapcqekhxQlY1llxcM
 github.com/aws/aws-sdk-go v1.46.0/go.mod h1:aVsgQcEevwlmQ7qHE9I3h+dtQgpqhFB+i8Phjh7fkwI=
 github.com/aws/aws-sdk-go-v2 v1.21.2 h1:+LXZ0sgo8quN9UOKXXzAWRT3FWd4NxeXWOZom9pE7GA=
 github.com/aws/aws-sdk-go-v2 v1.21.2/go.mod h1:ErQhvNuEMhJjweavOYhxVkn2RUx7kQXVATHrjKtxIpM=
+github.com/aws/aws-sdk-go-v2 v1.24.0 h1:890+mqQ+hTpNuw0gGP6/4akolQkSToDJgHfQE7AwGuk=
+github.com/aws/aws-sdk-go-v2 v1.24.0/go.mod h1:LNh45Br1YAkEKaAqvmE1m8FUx6a5b/V0oAKV7of29b4=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43 h1:nFBQlGtkbPzp/NjZLuFxRqmT91rLJkgvsEQs68h962Y=
 github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.43/go.mod h1:auo+PiyLl0n1l8A0e8RIeR8tOzYPfZZH/JNlrJ8igTQ=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9 h1:v+HbZaCGmOwnTTVS86Fleq0vPzOd7tnJGbFhP0stNLs=
+github.com/aws/aws-sdk-go-v2/internal/configsources v1.2.9/go.mod h1:Xjqy+Nyj7VDLBtCMkQYOw1QYfAEZCVLrfI0ezve8wd4=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37 h1:JRVhO25+r3ar2mKGP7E0LDl8K9/G36gjlqca5iQbaqc=
 github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.4.37/go.mod h1:Qe+2KtKml+FEsQF/DHmDV+xjtche/hwoF75EG4UlHW8=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9 h1:N94sVhRACtXyVcjXxrwK1SKFIJrA9pOJ5yu2eSHnmls=
+github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.5.9/go.mod h1:hqamLz7g1/4EJP+GH5NBhcUMLjW+gKLQabgyz6/7WAU=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.42.3 h1:E9TqN5noTqYsNYjN04AoWm/G1lYXzgZOao8YO6EbFKk=
+github.com/aws/aws-sdk-go-v2/service/cloudformation v1.42.3/go.mod h1:oPk8ZMctRUtGC13pOE83Zp0baZgJsmzuKm4IRR+zQOI=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.37 h1:WWZA/I2K4ptBS1kg0kV1JbBtG/umed0vwHRrmcr9z7k=
 github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.9.37/go.mod h1:vBmDnwWXWxNPFRMmG2m/3MKOe+xEcMDo1tanpaWCcck=
 github.com/aws/aws-sdk-go-v2/service/organizations v1.20.8 h1:FUd2lRsLCF+hKf7Ve9I10in/N0f+EVqZEXB/VZm8BZI=
@@ -29,6 +37,8 @@ github.com/aws/jsii-runtime-go v1.89.0 h1:1HKw9LyE8lOM9iMiSzVOUAVeUInTNhOyoxQrVV
 github.com/aws/jsii-runtime-go v1.89.0/go.mod h1:Jkx2jjw8wKQdQYzwh+JDDGy3MRPwKqDCeSvW6WWubi0=
 github.com/aws/smithy-go v1.15.0 h1:PS/durmlzvAFpQHDs4wi4sNNP9ExsqZh6IlfdHXgKK8=
 github.com/aws/smithy-go v1.15.0/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
+github.com/aws/smithy-go v1.19.0 h1:KWFKQV80DpP3vJrrA9sVAHQ5gc2z8i4EzrLhLlWXcBM=
+github.com/aws/smithy-go v1.19.0/go.mod h1:NukqUGpCZIILqqiV0NIjeFh24kd/FAa4beRb6nbIUPE=
 github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.200 h1:CwkS78cin4h5A3IaDcL69GrBI1HgTEB/xtECTf1luCc=
 github.com/cdklabs/awscdk-asset-awscli-go/awscliv1/v2 v2.2.200/go.mod h1:sx6+u9s3UHyhm9BGrkGdQgNA0Ni5ekbJ9hW2Gupvoy0=
 github.com/cdklabs/awscdk-asset-kubectl-go/kubectlv20/v2 v2.1.2 h1:k+WD+6cERd59Mao84v0QtRrcdZuuSMfzlEmuIypKnVs=

--- a/lib/awscloudformation/stacks.go
+++ b/lib/awscloudformation/stacks.go
@@ -1,0 +1,71 @@
+package awscloudformation
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/cloudformation"
+	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/aws/jsii-runtime-go"
+)
+
+type CFOutput struct {
+	Outputs []map[string]string
+}
+
+type Client struct {
+	client *cloudformation.CloudFormation
+}
+
+func New(creds *sts.Credentials) Client {
+	sess := session.Must(session.NewSession(&aws.Config{
+		Credentials: credentials.NewStaticCredentials(
+			*creds.AccessKeyId,
+			*creds.SecretAccessKey,
+			*creds.SessionToken,
+		),
+	}))
+	cfClient := cloudformation.New(sess)
+
+	stsClient := sts.New(sess)
+	_, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
+	if err != nil {
+		if awsErr, ok := err.(awserr.Error); ok {
+			switch awsErr.Code() {
+			case "UnrecognizedClientException", "InvalidClientTokenId", "AccessDenied":
+				fmt.Println("Error fetching caller identity. Ensure your awscli credentials are valid.\nError:", awsErr.Message())
+				panic(err)
+			}
+		}
+	}
+	return Client{
+		client: cfClient,
+	}
+}
+
+func (c Client) FetchStackOutputs(ctx context.Context, stackName string) ([]map[string]string, error) {
+	stack, err := c.client.DescribeStacksWithContext(ctx, &cloudformation.DescribeStacksInput{
+		StackName: jsii.String(stackName),
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	if len(stack.Stacks) != 1 {
+		return nil, fmt.Errorf("expected 1 stack (found: %d)", len(stack.Stacks))
+	}
+
+	var outputs []map[string]string
+	for _, output := range stack.Stacks[0].Outputs {
+		outputs = append(outputs, map[string]string{
+			"OutputKey":   *output.OutputKey,
+			"OutputValue": *output.OutputValue,
+		})
+	}
+
+	return outputs, nil
+}

--- a/lib/cdk/local.go
+++ b/lib/cdk/local.go
@@ -1,0 +1,129 @@
+package cdk
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+
+	"github.com/santiago-labs/telophasecli/lib/awscloudformation"
+	"github.com/santiago-labs/telophasecli/lib/cdk/template"
+	"github.com/santiago-labs/telophasecli/lib/ymlparser"
+)
+
+func getStackNames(stack ymlparser.Stack) ([]string, error) {
+	cmd := exec.Command("cdk", "ls")
+	output, err := cmd.Output()
+	if err != nil {
+		return []string{}, err
+	}
+
+	outputStr := string(output)
+	return strings.Split(outputStr, "\n"), nil
+}
+
+func templateOutput(cfnClient awscloudformation.Client, acct ymlparser.Account, stack ymlparser.Stack) (*template.CDKOutputs, error) {
+	var localTemplate template.CDKOutputs
+
+	tmpPath := TmpPath(acct, stack.Path)
+	var stackPathPrefix string
+	if stack.Path != "" {
+		stackPathPrefix += fmt.Sprintf("%s/", stack.Path)
+	}
+	rawFile, err := os.ReadFile(fmt.Sprintf("%s%s/%s.template.json", stackPathPrefix, tmpPath, stack.Name))
+	if err != nil {
+		return nil, err
+	}
+
+	err = json.Unmarshal(rawFile, &localTemplate)
+	if err != nil {
+		return nil, err
+	}
+
+	// We have to manually set the name because its not in the stack template.
+	localTemplate.StackName = stack.Name
+
+	return &localTemplate, nil
+}
+
+func StackLocalOutput(cfnClient awscloudformation.Client, acct ymlparser.Account, stack ymlparser.Stack) ([]*template.CDKOutputs, error) {
+	var stackTemplateOutputs []*template.CDKOutputs
+
+	if stack.Name == "" || stack.Name == "*" {
+		names, err := getStackNames(stack)
+		if err != nil {
+			return nil, err
+		}
+		for _, stackName := range names {
+			specificStack := ymlparser.Stack{
+				Path:            stack.Path,
+				RoleOverrideARN: stack.RoleOverrideARN,
+				Type:            stack.Type,
+				Name:            stackName,
+			}
+			output, err := templateOutput(cfnClient, acct, specificStack)
+			if err != nil {
+				return nil, err
+			}
+			stackTemplateOutputs = append(stackTemplateOutputs, output)
+		}
+	} else {
+		output, err := templateOutput(cfnClient, acct, stack)
+		if err != nil {
+			return nil, err
+		}
+		stackTemplateOutputs = append(stackTemplateOutputs, output)
+	}
+
+	return stackTemplateOutputs, nil
+}
+
+func StackRemoteOutput(cfnClient awscloudformation.Client, acct ymlparser.Account, stack ymlparser.Stack) ([]*template.CDKOutputs, error) {
+	localOutputs, err := StackLocalOutput(cfnClient, acct, stack)
+	if err != nil {
+		return []*template.CDKOutputs{}, err
+	}
+
+	// Mark deployed outputs that have changed
+	deployedTemplateOutputs, err := cfnClient.FetchTemplateOutputs(context.TODO(), stack.Name)
+	if err != nil {
+		return nil, err
+	}
+
+	for idx, output := range localOutputs {
+		templateOutputDiff := deployedTemplateOutputs.Diff(output)
+
+		outputVals, err := cfnClient.FetchStackOutputs(context.TODO(), output.StackName)
+		if err != nil {
+			return []*template.CDKOutputs{}, err
+		}
+
+		for _, outValue := range outputVals {
+			for varName := range output.Outputs {
+				if outValue["OutputKey"] == varName {
+					if updatedEval, ok := templateOutputDiff[template.Updated][varName]; ok {
+						localOutputs[idx].Outputs[varName] = updatedEval.(map[string]interface{})
+					} else {
+						localOutputs[idx].Outputs[varName]["Value"] = outValue["OutputValue"]
+					}
+				}
+			}
+		}
+	}
+
+	return localOutputs, nil
+}
+
+func TmpPath(acct ymlparser.Account, filePath string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(filePath))
+	hashBytes := hasher.Sum(nil)
+	hashString := hex.EncodeToString(hashBytes)
+
+	return path.Join("telophasedirs", fmt.Sprintf("cdk-tmp%s-%s", acct.AccountID, hashString))
+}

--- a/lib/cdk/template/template.go
+++ b/lib/cdk/template/template.go
@@ -1,0 +1,50 @@
+package template
+
+import "encoding/json"
+
+const (
+	Created = 1
+	Updated = 2
+	Deleted = 3
+)
+
+type CDKOutputs struct {
+	StackName string                            `yaml:"StackName" json:"StackName"`
+	Outputs   map[string]map[string]interface{} `yaml:"Outputs" json:"Outputs"`
+}
+
+func (c *CDKOutputs) Diff(other *CDKOutputs) map[int]map[string]interface{} {
+	diff := make(map[int]map[string]interface{})
+	diff[Created] = make(map[string]interface{})
+	diff[Updated] = make(map[string]interface{})
+	diff[Deleted] = make(map[string]interface{})
+
+	for key := range c.Outputs {
+		otherVal, ok := other.Outputs[key]
+		if !ok {
+			diff[Deleted][key] = c.Outputs[key]
+		} else {
+			otherValueSer, err := json.Marshal(otherVal["Value"])
+			if err != nil {
+				panic(err)
+			}
+
+			cValueSer, err := json.Marshal(c.Outputs[key]["Value"])
+			if err != nil {
+				panic(err)
+			}
+			if string(otherValueSer) != string(cValueSer) {
+				diff[Updated][key] = otherVal
+			}
+		}
+	}
+
+	for key := range other.Outputs {
+		_, ok := c.Outputs[key]
+		if !ok {
+			diff[Created][key] = other.Outputs[key]
+		}
+	}
+
+	return diff
+}

--- a/lib/terraform/local.go
+++ b/lib/terraform/local.go
@@ -1,0 +1,61 @@
+package terraform
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/santiago-labs/telophasecli/lib/ymlparser"
+)
+
+func TmpPath(acct ymlparser.Account, filePath string) string {
+	hasher := sha256.New()
+	hasher.Write([]byte(filePath))
+	hashBytes := hasher.Sum(nil)
+	hashString := hex.EncodeToString(hashBytes)
+
+	return path.Join("telophasedirs", fmt.Sprintf("tf-tmp%s-%s", acct.AccountID, hashString))
+}
+
+func CopyDir(src string, dst string, acct ymlparser.Account) error {
+	ignoreDir := "telophasedirs"
+
+	return filepath.Walk(src, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+
+		if strings.Contains(path, filepath.Join(src, ignoreDir)) {
+			return nil
+		}
+
+		relPath := strings.TrimPrefix(path, src)
+		targetPath := filepath.Join(dst, relPath)
+
+		if info.IsDir() {
+			return os.MkdirAll(targetPath, info.Mode())
+		} else {
+			return replaceVariablesInFile(path, targetPath, acct)
+		}
+	})
+}
+
+func replaceVariablesInFile(srcFile, dstFile string, acct ymlparser.Account) error {
+	content, err := ioutil.ReadFile(srcFile)
+	if err != nil {
+		return err
+	}
+
+	updatedContent := strings.ReplaceAll(string(content), "${telophase.account_id}", acct.AccountID)
+	updatedContent = strings.ReplaceAll(updatedContent, "telophase.account_id", fmt.Sprintf("\"%s\"", acct.AccountID))
+	updatedContent = strings.ReplaceAll(updatedContent, "${telophase.account_name}", acct.AccountName)
+	updatedContent = strings.ReplaceAll(updatedContent, "telophase.account_name", fmt.Sprintf("\"%s\"", acct.AccountName))
+
+	return ioutil.WriteFile(dstFile, []byte(updatedContent), 0644)
+}

--- a/lib/ymlparser/organizationv1.go
+++ b/lib/ymlparser/organizationv1.go
@@ -35,9 +35,10 @@ type Account struct {
 }
 
 type Stack struct {
-	Name string `yaml:"Name"`
-	Type string `yaml:"Type"`
-	Path string `yaml:"Path"`
+	Name            string `yaml:"Name"`
+	Type            string `yaml:"Type"`
+	Path            string `yaml:"Path"`
+	RoleOverrideARN string `yaml:"RoleOverrideARN,omitempty"`
 }
 
 func (a Account) AssumeRoleARN() string {
@@ -60,10 +61,10 @@ func (a Account) AllTags() []string {
 
 func (a Account) AllStacks() []Stack {
 	var stacks []Stack
-	stacks = append(stacks, a.Stacks...)
 	if a.Parent != nil {
 		stacks = append(stacks, a.Parent.AllStacks()...)
 	}
+	stacks = append(stacks, a.Stacks...)
 	return stacks
 }
 

--- a/lib/ymlparser/organizationv2.go
+++ b/lib/ymlparser/organizationv2.go
@@ -41,15 +41,14 @@ func (grp AccountGroup) AllTags() []string {
 
 func (grp AccountGroup) AllStacks() []Stack {
 	var stacks []Stack
-	stacks = append(stacks, grp.Stacks...)
 	if grp.Parent != nil {
 		stacks = append(stacks, grp.Parent.AllStacks()...)
 	}
+	stacks = append(stacks, grp.Stacks...)
 	return stacks
 }
 
 // grp == configuration in organization.yml.
-// other == configuration in cloud provider.
 func (grp AccountGroup) Diff(orgClient awsorgs.Client) []ResourceOperation {
 	// Order of operations matters. Groups must be created first, followed by account creation,
 	// and finally (re)parenting groups and accounts.


### PR DESCRIPTION
- Changed the order of `AllStacks` to order ancestor stacks first then descendants. Descendants were ordered first which was unintentional

-  Move cdk and terraform logic that manipulates cdk or terraform files into their own package

-  Outputs are passed across stack executions as context (ie `--context <stack name>.<output key>=<value>`)

Here's how output passing works:
After stack `cdk diff` and `cdk deploy`, we read outputs from the locally synthesized stack. We then check if the stack has been deployed, and if it has, reconcile the deployed outputs with the local outputs. During reconciliation, outputs that have changed locally or aren't yet deployed are passed as the raw CDK eval (e.g. `<stack>.<output key>={"Value": {"Fn::Join": [",", {"Fn::GetAtt": ["myHostedZone", "NameServers"]}]}}`). Unchanged outputs are fetched from the executed stack in AWS and passed as a string (e.g. `<stack>.<output key>="ns-1474.awsdns-56.org,ns-799.awsdns-35.net,ns-348.awsdns-43.com,ns-1558.awsdns-02.co.uk"`)