### PR TITLE
Ethan/baseline iac

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -26,10 +26,8 @@ import (
 )
 
 var (
-	cdkPath string
-	tfPath  string
-	tag     string
-	stacks  string
+	tag    string
+	stacks string
 
 	// TUI
 	useTUI   bool
@@ -39,8 +37,6 @@ var (
 
 func init() {
 	rootCmd.AddCommand(compileCmd)
-	compileCmd.Flags().StringVar(&cdkPath, "cdk-path", "", "Path to your CDK code")
-	compileCmd.Flags().StringVar(&tfPath, "tf-path", "", "Path to your Terraform code")
 	compileCmd.Flags().StringVar(&stacks, "stacks", "", "Filter stacks to deploy")
 	compileCmd.Flags().StringVar(&tag, "tag", "", "Filter accounts and account groups to deploy")
 	compileCmd.Flags().StringVar(&orgFile, "org", "organization.yml", "Path to the organization.yml file")

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -27,8 +27,6 @@ import (
 
 func init() {
 	rootCmd.AddCommand(diffCmd)
-	diffCmd.Flags().StringVar(&cdkPath, "cdk-path", "", "Path to your CDK code")
-	diffCmd.Flags().StringVar(&tfPath, "tf-path", "", "Path to your TF code")
 	diffCmd.Flags().StringVar(&stacks, "stacks", "", "Filter stacks to deploy")
 	diffCmd.Flags().StringVar(&tag, "tag", "", "Filter accounts and account groups to deploy.")
 	diffCmd.Flags().StringVar(&orgFile, "org", "organization.yml", "Path to the organization.yml file")

--- a/cmd/provisionaccounts.go
+++ b/cmd/provisionaccounts.go
@@ -15,7 +15,6 @@ import (
 	"github.com/santiago-labs/telophasecli/lib/awsorgs"
 	"github.com/santiago-labs/telophasecli/lib/awssess"
 	"github.com/santiago-labs/telophasecli/lib/azureorgs"
-	"github.com/santiago-labs/telophasecli/lib/telophase"
 	"github.com/santiago-labs/telophasecli/lib/ymlparser"
 )
 
@@ -143,18 +142,9 @@ func currentAccountID() (string, error) {
 }
 
 func importOrgV2(orgClient awsorgs.Client) error {
-	accounts, err := orgClient.CurrentAccounts(context.Background())
-	if err != nil {
-		return fmt.Errorf("error: %s getting current accounts", err)
-	}
-
 	managingAccountID, err := currentAccountID()
 	if err != nil {
 		return err
-	}
-
-	for _, acct := range accounts {
-		telophase.UpsertAccount(*acct.Id, *acct.Name)
 	}
 
 	rootId, err := orgClient.GetRootId()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/santiago-labs/telophasecli/lib/metrics"
-	"github.com/santiago-labs/telophasecli/lib/telophase"
 	"github.com/spf13/cobra"
 )
 
@@ -22,13 +21,6 @@ func Execute() {
 	metrics.Init()
 	metrics.RegisterCommand()
 	defer metrics.Close()
-
-	token := "TELOPHASE_TOKEN"
-	if !telophase.ValidTelophaseToken(token) {
-		if token != "ignore" {
-			fmt.Println("(Optional) Signup for Telophase for an even better experience! https://app.telophase.dev. Set TELOPHASE_TOKEN=ignore in your env to hide this message.")
-		}
-	}
 
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Fprintf(os.Stderr, "Whoops. There was an error while executing your CLI '%s'", err)

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -5,12 +5,10 @@ Usage:
   telophasecli diff [flags]
 
 Flags:
-      --cdk-path string   Path to your CDK code
   -h, --help              help for diff
       --org string        Path to the organization.yml file (default "organization.yml")
       --stacks string     Filter stacks to deploy
       --tag string        Filter accounts and account groups to deploy.
-      --tf-path string    Path to your TF code
       --tui               use the TUI for diff
 ```
 
@@ -26,12 +24,10 @@ Usage:
   telophasecli deploy [flags]
 
 Flags:
-      --cdk-path string   Path to your CDK code
   -h, --help              help for deploy
       --org string        Path to the organization.yml file (default "organization.yml")
       --stacks string     Filter stacks to deploy
       --tag string        Filter accounts and account groups to deploy
-      --tf-path string    Path to your Terraform code
       --tui               use the TUI for deploy
 ```
 
@@ -51,7 +47,7 @@ Flags:
       --org string   Path to the organization.yml file (default "organization.yml")
 ```
 
-This command reads your AWS Organization and outputs `organization.yml`. We do not yet support import Azure Subscriptions.
+This command reads your AWS Organization and outputs `organization.yml`. It must be run in your AWS Management Account. We do not yet support importing Azure Subscriptions.
 
 ### `telophasecli account diff`
 ```sh

--- a/examples/tf/SCPs/restrict_to_eu/main.tf
+++ b/examples/tf/SCPs/restrict_to_eu/main.tf
@@ -1,0 +1,28 @@
+data "aws_iam_policy_document" "restrict_regions" {
+  statement {
+    sid       = "RegionRestriction"
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:RequestedRegion"
+
+      values = [
+        "eu-west-1"
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "restrict_regions" {
+  name        = "restrict_regions"
+  description = "Deny all regions except EU West 1."
+  content     = data.aws_iam_policy_document.restrict_regions.json
+}
+
+resource "aws_organizations_policy_attachment" "restrict_regions_on_account" {
+  policy_id = aws_organizations_policy.restrict_regions.id
+  target_id = telophase.account_id
+}

--- a/examples/tf/SCPs/restrict_to_us/main.tf
+++ b/examples/tf/SCPs/restrict_to_us/main.tf
@@ -1,0 +1,28 @@
+data "aws_iam_policy_document" "restrict_regions" {
+  statement {
+    sid       = "RegionRestriction"
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:RequestedRegion"
+
+      values = [
+        "us-east-1"
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "restrict_regions" {
+  name        = "restrict_regions"
+  description = "Deny all regions except US East 1."
+  content     = data.aws_iam_policy_document.restrict_regions.json
+}
+
+resource "aws_organizations_policy_attachment" "restrict_regions_on_account" {
+  policy_id = aws_organizations_policy.restrict_regions.id
+  target_id = telophase.account_id
+}

--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -11,7 +11,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/santiago-labs/telophasecli/lib/awssess"
-	"github.com/santiago-labs/telophasecli/lib/telophase"
 )
 
 type Client struct {
@@ -241,7 +240,6 @@ func (c Client) CreateAccounts(ctx context.Context, accts []*organizations.Accou
 				requestToAccount[requestId].Id = currStatus.CreateAccountStatus.AccountId
 				fmt.Printf("Successfully created account %s.\n", accountName)
 				requestsInProgress -= 1
-				telophase.UpsertAccount(*currStatus.CreateAccountStatus.AccountId, accountName)
 			}
 		}
 	}

--- a/lib/ymlparser/organizationv2.go
+++ b/lib/ymlparser/organizationv2.go
@@ -25,13 +25,14 @@ type orgDatav2 struct {
 }
 
 type AccountGroup struct {
-	ID          *string         `yaml:"-"`
-	Name        string          `yaml:"Name,omitempty"`
-	ChildGroups []*AccountGroup `yaml:"AccountGroups,omitempty"`
-	Tags        []string        `yaml:"Tags,omitempty"`
-	Accounts    []*Account      `yaml:"Accounts,omitempty"`
-	Stacks      []Stack         `yaml:"Stacks,omitempty"`
-	Parent      *AccountGroup   `yaml:"-"`
+	ID                     *string         `yaml:"-"`
+	Name                   string          `yaml:"Name,omitempty"`
+	ChildGroups            []*AccountGroup `yaml:"AccountGroups,omitempty"`
+	Tags                   []string        `yaml:"Tags,omitempty"`
+	Accounts               []*Account      `yaml:"Accounts,omitempty"`
+	BaselineStacks         []Stack         `yaml:"Stacks,omitempty"`
+	ServiceControlPolicies []Stack         `yaml:"ServiceControlPolicies,omitempty"`
+	Parent                 *AccountGroup   `yaml:"-"`
 }
 
 type AzureAccountGroup struct {
@@ -61,7 +62,7 @@ type Subscription struct {
 	SubscriptionName string   `yaml:"Name"`
 	Account          *Account `yaml:"Account"`
 
-	Stacks []Stack `yaml:"Stacks,omitempty"`
+	BaselineStacks []Stack `yaml:"Stacks,omitempty"`
 }
 
 func (grp AccountGroup) AllTags() []string {
@@ -73,12 +74,12 @@ func (grp AccountGroup) AllTags() []string {
 	return tags
 }
 
-func (grp AccountGroup) AllStacks() []Stack {
+func (grp AccountGroup) AllBaselineStacks() []Stack {
 	var stacks []Stack
 	if grp.Parent != nil {
-		stacks = append(stacks, grp.Parent.AllStacks()...)
+		stacks = append(stacks, grp.Parent.AllBaselineStacks()...)
 	}
-	stacks = append(stacks, grp.Stacks...)
+	stacks = append(stacks, grp.BaselineStacks...)
 	return stacks
 }
 
@@ -317,7 +318,7 @@ func hydrateSubscriptions(subsClient *azureorgs.Client, azureGroup *AzureAccount
 				azureGroup.Subscriptions[i].Account = &Account{
 					SubscriptionID: strings.Split(*liveSub.ID, "/")[2],
 					AccountName:    *liveSub.DisplayName,
-					Stacks:         sub.Stacks,
+					BaselineStacks: sub.BaselineStacks,
 				}
 			}
 		}


### PR DESCRIPTION
1. Remove CLI options for passing stacks. Stacks should be assigned to OUs or Accounts in `organization.yml`
2. Remove calls to telophase backend. We're focusing on CLI usability right now, and will come back to this later.
3. Introduce Service Control Policies