### PR TITLE
Merge TUI and STD out

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -42,7 +42,6 @@ var compileCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "deploy - Deploy a CDK and/or TF stacks to your AWS account(s). Accounts in organization.yml will be created if they do not exist.",
 	Run: func(cmd *cobra.Command, args []string) {
-
 		orgClient := awsorgs.New()
 		subsClient, err := azureorgs.New()
 		if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -6,10 +6,9 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-	"sync"
-	"sync/atomic"
 
 	"github.com/samsarahq/go/oops"
+	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/lib/awsorgs"
 	"github.com/santiago-labs/telophasecli/lib/awssts"
 	"github.com/santiago-labs/telophasecli/lib/azureiam"
@@ -28,9 +27,7 @@ var (
 	stacks string
 
 	// TUI
-	useTUI   bool
-	tuiIndex atomic.Int64
-	tuiLock  sync.Mutex
+	useTUI bool
 )
 
 func init() {
@@ -45,7 +42,55 @@ var compileCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "deploy - Deploy a CDK and/or TF stacks to your AWS account(s). Accounts in organization.yml will be created if they do not exist.",
 	Run: func(cmd *cobra.Command, args []string) {
-		runIAC(deployIAC{})
+
+		orgClient := awsorgs.New()
+		subsClient, err := azureorgs.New()
+		if err != nil {
+			panic(fmt.Sprintf("error: %s", err))
+		}
+		ctx := context.Background()
+
+		var accountsToApply []ymlparser.Account
+
+		ops, err := orgV2Diff(orgClient, subsClient)
+		if err != nil {
+			panic(fmt.Sprintf("error: %s", err))
+		}
+
+		for _, op := range ops {
+			op.Call(ctx, orgClient)
+		}
+		awsGroup, azureGroup, err := ymlparser.ParseOrganizationV2(orgFile)
+		if err != nil {
+			panic(fmt.Sprintf("error: %s parsing organization", err))
+		}
+		if awsGroup != nil {
+			for _, acct := range awsGroup.AllDescendentAccounts() {
+				if contains(tag, acct.AllTags()) || tag == "" {
+					accountsToApply = append(accountsToApply, *acct)
+				}
+			}
+		}
+
+		if azureGroup != nil {
+			for _, acct := range azureGroup.AllDescendentAccounts() {
+				if contains(tag, acct.AllTags()) || tag == "" {
+					accountsToApply = append(accountsToApply, *acct)
+				}
+			}
+		}
+
+		if len(accountsToApply) == 0 {
+			fmt.Println("No accounts to deploy")
+		}
+
+		var consoleUI runner.ConsoleUI
+		if useTUI {
+			consoleUI = runner.NewTUI()
+		} else {
+			consoleUI = runner.NewSTDOut()
+		}
+		runIAC(deployIAC{}, accountsToApply, consoleUI)
 	},
 }
 
@@ -93,15 +138,4 @@ func (d deployIAC) tfCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, s
 	}
 
 	return cmd
-}
-
-func (d deployIAC) orgV2Cmd(ctx context.Context, orgClient awsorgs.Client, subsClient *azureorgs.Client) {
-	ops, err := orgV2Diff(orgClient, subsClient)
-	if err != nil {
-		panic(fmt.Sprintf("error: %s", err))
-	}
-
-	for _, op := range ops {
-		op.Call(ctx, orgClient)
-	}
 }

--- a/cmd/iac.go
+++ b/cmd/iac.go
@@ -34,6 +34,7 @@ func runIAC(cmd iacCmd, accountsToApply []ymlparser.Account, consoleUI runner.Co
 		go func(acct ymlparser.Account) {
 			defer wg.Done()
 			if !acct.IsProvisioned() {
+				consoleUI.Print(fmt.Sprintf("skipping account: %s because it hasn't been provisioned yet", acct.AccountName), acct)
 				return
 			}
 

--- a/cmd/iac.go
+++ b/cmd/iac.go
@@ -16,6 +16,7 @@ import (
 	"github.com/santiago-labs/telophasecli/lib/awssess"
 	"github.com/santiago-labs/telophasecli/lib/awssts"
 	"github.com/santiago-labs/telophasecli/lib/azureiam"
+	"github.com/santiago-labs/telophasecli/lib/cdk"
 	"github.com/santiago-labs/telophasecli/lib/localstack"
 	"github.com/santiago-labs/telophasecli/lib/terraform"
 	"github.com/santiago-labs/telophasecli/lib/ymlparser"
@@ -122,7 +123,7 @@ func authAWS(acct ymlparser.Account, stack ymlparser.Stack, consoleUI runner.Con
 		return awssess.AssumeRole(svc, input)
 	}
 
-	consoleUI.Print("Assuming role", acct)
+	consoleUI.Print(fmt.Sprintf("Assuming role: %s", acct.AssumeRoleARN()), acct)
 	input := &sts.AssumeRoleInput{
 		RoleArn:         aws.String(acct.AssumeRoleARN()),
 		RoleSessionName: aws.String("telophase-org"),

--- a/cmd/iac.go
+++ b/cmd/iac.go
@@ -1,30 +1,21 @@
 package cmd
 
 import (
-	"bufio"
-	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
-	"github.com/rivo/tview"
 	"github.com/samsarahq/go/oops"
-	"github.com/santiago-labs/telophasecli/lib/awsorgs"
+	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/lib/awssess"
 	"github.com/santiago-labs/telophasecli/lib/awssts"
 	"github.com/santiago-labs/telophasecli/lib/azureiam"
-	"github.com/santiago-labs/telophasecli/lib/azureorgs"
-	"github.com/santiago-labs/telophasecli/lib/cdk"
-	"github.com/santiago-labs/telophasecli/lib/colors"
 	"github.com/santiago-labs/telophasecli/lib/localstack"
 	"github.com/santiago-labs/telophasecli/lib/terraform"
 	"github.com/santiago-labs/telophasecli/lib/ymlparser"
@@ -33,77 +24,16 @@ import (
 type iacCmd interface {
 	cdkCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, stack ymlparser.Stack) *exec.Cmd
 	tfCmd(result *sts.AssumeRoleOutput, acct ymlparser.Account, stack ymlparser.Stack) *exec.Cmd
-	orgV2Cmd(ctx context.Context, orgClient awsorgs.Client, subsClient *azureorgs.Client)
 }
 
-func runIAC(cmd iacCmd) {
-	orgClient := awsorgs.New()
-	subsClient, err := azureorgs.New()
-	if err != nil {
-		panic(fmt.Sprintf("error: %s", err))
-	}
-	ctx := context.Background()
-
-	var accountsToApply []ymlparser.Account
-
-	cmd.orgV2Cmd(ctx, orgClient, subsClient)
-	awsGroup, azureGroup, err := ymlparser.ParseOrganizationV2(orgFile)
-	if err != nil {
-		panic(fmt.Sprintf("error: %s parsing organization", err))
-	}
-	if awsGroup != nil {
-		for _, acct := range awsGroup.AllDescendentAccounts() {
-			if contains(tag, acct.AllTags()) || tag == "" {
-				accountsToApply = append(accountsToApply, *acct)
-			}
-		}
-	}
-
-	if azureGroup != nil {
-		for _, acct := range azureGroup.AllDescendentAccounts() {
-			if contains(tag, acct.AllTags()) || tag == "" {
-				accountsToApply = append(accountsToApply, *acct)
-			}
-		}
-	}
-
-	if len(accountsToApply) == 0 {
-		fmt.Println("No accounts to deploy")
-	}
-
-	if useTUI {
-		deployTUI(cmd, accountsToApply)
-		return
-	}
-
-	// Now for each to apply we will take that and write to stdout.
+func runIAC(cmd iacCmd, accountsToApply []ymlparser.Account, consoleUI runner.ConsoleUI) {
 	var wg sync.WaitGroup
 	for i := range accountsToApply {
 		wg.Add(1)
 		go func(acct ymlparser.Account) {
-			colorFunc := colors.DeterministicColorFunc(acct.AccountID)
 			defer wg.Done()
-			if acct.AccountID == "" && acct.SubscriptionID == "" {
-				fmt.Println(colorFunc(fmt.Sprintf("skipping account: %s because it hasn't been provisioned yet", acct.AccountName)))
+			if !acct.IsProvisioned() {
 				return
-			}
-			var accountRole *sts.AssumeRoleOutput
-			var svc *sts.STS
-			sess := session.Must(awssess.DefaultSession())
-			svc = sts.New(sess)
-			if acct.AccountID != "" {
-				fmt.Println("assuming role", colorFunc(acct.AssumeRoleARN()))
-				input := &sts.AssumeRoleInput{
-					RoleArn:         aws.String(acct.AssumeRoleARN()),
-					RoleSessionName: aws.String("telophase-org"),
-				}
-
-				var err error
-				accountRole, err = awssess.AssumeRole(svc, input)
-				if err != nil {
-					fmt.Println("Error assuming role:", err)
-					return
-				}
 			}
 
 			var acctStacks []ymlparser.Stack
@@ -113,62 +43,56 @@ func runIAC(cmd iacCmd) {
 				acctStacks = append(acctStacks, acct.AllBaselineStacks()...)
 			}
 
-			coloredAccountID := colorFunc("[Account: " + acct.ID() + "]")
-
 			if len(acctStacks) == 0 {
-				fmt.Printf("%s No stacks to deploy\n", coloredAccountID)
+				consoleUI.Print("No stacks to deploy\n", acct)
 				return
 			}
 
 			var bootstrappedCDK bool
 			for _, stack := range acctStacks {
-				fmt.Printf("%s executing stack: %s (empty string means all stacks) \n", coloredAccountID, stack.Name)
-				stackRole := accountRole
-				if stack.RoleOverrideARN != "" {
-					fmt.Printf("%s assuming role: %s \n", coloredAccountID, colorFunc(stack.RoleOverrideARN))
-					input := &sts.AssumeRoleInput{
-						RoleArn:         aws.String(stack.RoleOverrideARN),
-						RoleSessionName: aws.String("telophase-org"),
-					}
+				consoleUI.Print(fmt.Sprintf("executing stack: %s (empty string means all stacks) \n", stack.Name), acct)
+				var stackRole *sts.AssumeRoleOutput
 
-					stackRole, err = awssess.AssumeRole(svc, input)
+				if acct.AccountID != "" {
+					var err error
+					stackRole, err = authAWS(acct, stack, consoleUI)
 					if err != nil {
-						fmt.Println("Error assuming role:", err)
+						consoleUI.Print(fmt.Sprintf("[ERROR] %v\n", err), acct)
 						return
 					}
 				}
 				if stack.Type == "CDK" {
 					if !bootstrappedCDK {
 						bootstrapCDK := bootstrapCDK(stackRole, acct, stack)
-						if err := runCmd(bootstrapCDK, acct, coloredAccountID); err != nil {
-							fmt.Printf("[ERROR] %s %v\n", coloredAccountID, err)
+						if err := consoleUI.RunCmd(bootstrapCDK, acct); err != nil {
+							consoleUI.Print(fmt.Sprintf("[ERROR] %v\n", err), acct)
 							return
 						}
 						bootstrappedCDK = true
 					}
 
 					synthCDK := synthCDK(stackRole, acct, stack)
-					if err := runCmd(synthCDK, acct, coloredAccountID); err != nil {
-						fmt.Printf("[ERROR] %s %v\n", coloredAccountID, err)
+					if err := consoleUI.RunCmd(synthCDK, acct); err != nil {
+						consoleUI.Print(fmt.Sprintf("[ERROR] %v\n", err), acct)
 						return
 					}
 					deployCDKCmd := cmd.cdkCmd(stackRole, acct, stack)
-					if err := runCmd(deployCDKCmd, acct, coloredAccountID); err != nil {
-						fmt.Printf("[ERROR] %s %v\n", coloredAccountID, err)
+					if err := consoleUI.RunCmd(deployCDKCmd, acct); err != nil {
+						consoleUI.Print(fmt.Sprintf("[ERROR] %v\n", err), acct)
 						return
 					}
 
 				} else if stack.Type == "Terraform" {
 					initTFCmd := initTf(stackRole, acct, stack)
 					if initTFCmd != nil {
-						if err := runCmd(initTFCmd, acct, coloredAccountID); err != nil {
-							fmt.Printf("[ERROR] %s %v\n", coloredAccountID, err)
+						if err := consoleUI.RunCmd(initTFCmd, acct); err != nil {
+							consoleUI.Print(fmt.Sprintf("[ERROR] %v\n", err), acct)
 							return
 						}
 					}
 					deployTFCmd := cmd.tfCmd(stackRole, acct, stack)
-					if err := runCmd(deployTFCmd, acct, coloredAccountID); err != nil {
-						fmt.Printf("[ERROR] %s %v\n", coloredAccountID, err)
+					if err := consoleUI.RunCmd(deployTFCmd, acct); err != nil {
+						consoleUI.Print(fmt.Sprintf("[ERROR] %v\n", err), acct)
 						return
 					}
 				} else {
@@ -178,50 +102,33 @@ func runIAC(cmd iacCmd) {
 		}(accountsToApply[i])
 	}
 
+	consoleUI.PostProcess()
+
 	wg.Wait()
 }
 
-// runCmd takes the command and acct and runs it while prepending the
-// coloredAccountID from stderr and stdout and printing it.
-func runCmd(cmd *exec.Cmd, acct ymlparser.Account, coloredAccountID string) error {
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("[ERROR] %s %v", coloredAccountID, err)
-	}
-	stdoutScanner := bufio.NewScanner(stdoutPipe)
+func authAWS(acct ymlparser.Account, stack ymlparser.Stack, consoleUI runner.ConsoleUI) (*sts.AssumeRoleOutput, error) {
+	var svc *sts.STS
+	sess := session.Must(awssess.DefaultSession())
+	svc = sts.New(sess)
 
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("[ERROR] %s %v", coloredAccountID, err)
-	}
-	stderrScanner := bufio.NewScanner(stderrPipe)
-
-	if err := cmd.Start(); err != nil {
-		return fmt.Errorf("[ERROR] %s %v", coloredAccountID, err)
-	}
-
-	var scannerWg sync.WaitGroup
-	scannerWg.Add(2)
-	scanF := func(scanner *bufio.Scanner, name string) {
-		defer scannerWg.Done()
-		for scanner.Scan() {
-			fmt.Printf("%s %s\n", coloredAccountID, scanner.Text())
+	if stack.RoleOverrideARN != "" {
+		consoleUI.Print(fmt.Sprintf("Assuming role: %s", stack.RoleOverrideARN), acct)
+		input := &sts.AssumeRoleInput{
+			RoleArn:         aws.String(stack.RoleOverrideARN),
+			RoleSessionName: aws.String("telophase-org"),
 		}
-		if err := scanner.Err(); err != nil {
-			fmt.Printf("[ERROR] %s %v\n", coloredAccountID, err)
-			return
-		}
+
+		return awssess.AssumeRole(svc, input)
 	}
 
-	go scanF(stdoutScanner, "stdout")
-	go scanF(stderrScanner, "stderr")
-	scannerWg.Wait()
-
-	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("[ERROR] %s %v", coloredAccountID, err)
+	consoleUI.Print("Assuming role", acct)
+	input := &sts.AssumeRoleInput{
+		RoleArn:         aws.String(acct.AssumeRoleARN()),
+		RoleSessionName: aws.String("telophase-org"),
 	}
 
-	return nil
+	return awssess.AssumeRole(svc, input)
 }
 
 func bootstrapCDK(result *sts.AssumeRoleOutput, acct ymlparser.Account, stack ymlparser.Stack) *exec.Cmd {
@@ -312,212 +219,4 @@ func contains(e string, s []string) bool {
 		}
 	}
 	return false
-}
-
-func deployTUI(cmd iacCmd, orgsToApply []ymlparser.Account) error {
-	app := tview.NewApplication()
-	tv := tview.NewTextView().SetDynamicColors(true)
-
-	main := tv.
-		SetTextAlign(tview.AlignLeft).SetScrollable(true).
-		SetChangedFunc(func() {
-			tv.ScrollToEnd()
-			app.Draw()
-		}).SetText("Starting CDK...")
-
-	list := tview.NewList()
-	var tails []*func() string
-
-	// Now for each to apply we will take that and write to stdout.
-	var wg sync.WaitGroup
-	for i := range orgsToApply {
-		file, err := ioutil.TempFile("/tmp", orgsToApply[i].AccountID)
-		if err != nil {
-			return err
-		}
-
-		setter := func() string {
-			bytes, err := ioutil.ReadFile(file.Name())
-			if err != nil {
-				fmt.Printf("ERR: %s", err)
-				return ""
-			}
-
-			return string(bytes)
-		}
-
-		tails = append(tails, &setter)
-
-		wrapI := i
-		acctId := orgsToApply[wrapI].ID()
-		if acctId == "" {
-			acctId = "Not Yet Provisioned"
-		}
-
-		list.AddItem(acctId, orgsToApply[wrapI].AccountName, runeIndex(i), func() {
-			currText := *tails[wrapI]
-			// And we want to call this on repeat
-			tuiIndex.Swap(int64(wrapI))
-			tuiLock.Lock()
-			defer tuiLock.Unlock()
-			main.SetText(tview.TranslateANSI(currText()))
-		})
-
-		wg.Add(1)
-		go func(acct ymlparser.Account, file *os.File) {
-			defer wg.Done()
-			if !acct.IsProvisioned() {
-				return
-			}
-
-			var accountRole *sts.AssumeRoleOutput
-			var svc *sts.STS
-			if acct.AccountID != "" {
-				sess := session.Must(awssess.DefaultSession())
-				svc = sts.New(sess)
-				input := &sts.AssumeRoleInput{
-					RoleArn:         aws.String(acct.AssumeRoleARN()),
-					RoleSessionName: aws.String("telophase-org"),
-				}
-				var err error
-				accountRole, err = awssess.AssumeRole(svc, input)
-				if err != nil {
-					fmt.Fprint(file, "Error assuming role:", err)
-					return
-				}
-			}
-
-			var acctStacks []ymlparser.Stack
-			if stacks != "" && stacks != "*" {
-				acctStacks = append(acctStacks, acct.FilterBaselineStacks(stacks)...)
-			} else {
-				acctStacks = append(acctStacks, acct.AllBaselineStacks()...)
-			}
-
-			if len(acctStacks) == 0 {
-				fmt.Fprint(file, "No stacks to deploy\n")
-				return
-			}
-
-			var bootstrappedCDK bool
-			for _, stack := range acctStacks {
-				fmt.Fprintf(file, "executing stack: %s (empty means all) \n", stack.Name)
-				stackRole := accountRole
-				if stack.RoleOverrideARN != "" {
-					fmt.Fprintf(file, "assuming role: %s", stack.RoleOverrideARN)
-					input := &sts.AssumeRoleInput{
-						RoleArn:         aws.String(stack.RoleOverrideARN),
-						RoleSessionName: aws.String("telophase-org"),
-					}
-
-					stackRole, err = awssess.AssumeRole(svc, input)
-					if err != nil {
-						fmt.Println("Error assuming role:", err)
-						return
-					}
-				}
-				if stack.Type == "CDK" {
-					if !bootstrappedCDK {
-						bootstrapCDK := bootstrapCDK(stackRole, acct, stack)
-						if err := runCmdWriter(bootstrapCDK, acct, file); err != nil {
-							return
-						}
-						bootstrappedCDK = true
-					}
-
-					synthCDK := synthCDK(stackRole, acct, stack)
-					if err := runCmdWriter(synthCDK, acct, file); err != nil {
-						return
-					}
-
-					deployCDKCmd := cmd.cdkCmd(stackRole, acct, stack)
-					if err := runCmdWriter(deployCDKCmd, acct, file); err != nil {
-						return
-					}
-				} else if stack.Type == "Terraform" {
-					initTFCmd := initTf(stackRole, acct, stack)
-					if initTFCmd != nil {
-						if err := runCmdWriter(initTFCmd, acct, file); err != nil {
-							return
-						}
-					}
-					deployTFCmd := cmd.tfCmd(stackRole, acct, stack)
-					if err := runCmdWriter(deployTFCmd, acct, file); err != nil {
-						return
-					}
-				} else {
-					panic(fmt.Errorf("unsupported stack type: %s", stack.Type))
-				}
-			}
-		}(orgsToApply[i], file)
-	}
-
-	list.AddItem("Quit", "Press to exit", 'q', func() {
-		app.Stop()
-	})
-
-	// Start index at 0 for the first account.
-	tuiIndex.Swap(0)
-
-	go liveTextSetter(main, tails)
-
-	grid := tview.NewGrid().
-		SetColumns(-1, -3).
-		SetRows(-1).
-		SetBorders(true)
-
-	// Layout for screens wider than 100 cells.
-	grid.AddItem(list, 0, 0, 1, 1, 0, 100, false).
-		AddItem(main, 0, 1, 1, 1, 0, 100, false)
-
-	if err := app.SetRoot(grid, true).SetFocus(list).Run(); err != nil {
-		panic(err)
-	}
-
-	wg.Wait()
-	return nil
-}
-
-func runeIndex(i int) rune {
-	j := 0
-	for r := 'a'; r <= 'p'; r++ {
-		if j == i {
-			return r
-		}
-		j++
-	}
-
-	return 'z'
-}
-
-func runCmdWriter(cmd *exec.Cmd, org ymlparser.Account, writer io.Writer) error {
-	cmd.Stderr = writer
-	cmd.Stdout = writer
-
-	if err := cmd.Start(); err != nil {
-		return err
-	}
-
-	if err := cmd.Wait(); err != nil {
-		return err
-	}
-	return nil
-}
-
-// liveTextSetter updates the current tui view with the current tail's text.
-func liveTextSetter(tv *tview.TextView, tails []*func() string) {
-	for {
-		func() {
-			time.Sleep(200 * time.Millisecond)
-			tuiLock.Lock()
-			defer tuiLock.Unlock()
-			f := *tails[tuiIndex.Load()]
-
-			curr := tv.GetText(true)
-			newText := f()
-			if newText != curr && newText != "" {
-				tv.SetText(tview.TranslateANSI(f()))
-			}
-		}()
-	}
 }

--- a/cmd/runner/interface.go
+++ b/cmd/runner/interface.go
@@ -1,0 +1,13 @@
+package runner
+
+import (
+	"os/exec"
+
+	"github.com/santiago-labs/telophasecli/lib/ymlparser"
+)
+
+type ConsoleUI interface {
+	Print(string, ymlparser.Account)
+	RunCmd(*exec.Cmd, ymlparser.Account) error
+	PostProcess()
+}

--- a/cmd/runner/stdout.go
+++ b/cmd/runner/stdout.go
@@ -30,7 +30,7 @@ func (s *stdOut) ColoredId(acct ymlparser.Account) string {
 	return coloredId
 }
 
-// runCmd takes the command and acct and runs it while prepending the
+// RunCmd takes the command and acct and runs it while prepending the
 // coloredAccountID from stderr and stdout and printing it.
 func (s *stdOut) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
 	stdoutPipe, err := cmd.StdoutPipe()

--- a/cmd/runner/stdout.go
+++ b/cmd/runner/stdout.go
@@ -20,7 +20,7 @@ type stdOut struct {
 	coloredId map[string]string
 }
 
-func (s stdOut) ColoredId(acct ymlparser.Account) string {
+func (s *stdOut) ColoredId(acct ymlparser.Account) string {
 	coloredId, ok := s.coloredId[acct.ID()]
 	if !ok {
 		colorFunc := colors.DeterministicColorFunc(acct.AccountID)
@@ -32,7 +32,7 @@ func (s stdOut) ColoredId(acct ymlparser.Account) string {
 
 // runCmd takes the command and acct and runs it while prepending the
 // coloredAccountID from stderr and stdout and printing it.
-func (s stdOut) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
+func (s *stdOut) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
 	stdoutPipe, err := cmd.StdoutPipe()
 	if err != nil {
 		return fmt.Errorf("[ERROR] %s %v", s.ColoredId(acct), err)
@@ -73,8 +73,8 @@ func (s stdOut) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
 	return nil
 }
 
-func (s stdOut) Print(msg string, acct ymlparser.Account) {
+func (s *stdOut) Print(msg string, acct ymlparser.Account) {
 	fmt.Printf("%s %v\n", s.ColoredId(acct), msg)
 }
 
-func (s stdOut) PostProcess() {}
+func (s *stdOut) PostProcess() {}

--- a/cmd/runner/stdout.go
+++ b/cmd/runner/stdout.go
@@ -1,0 +1,80 @@
+package runner
+
+import (
+	"bufio"
+	"fmt"
+	"os/exec"
+	"sync"
+
+	"github.com/santiago-labs/telophasecli/lib/colors"
+	"github.com/santiago-labs/telophasecli/lib/ymlparser"
+)
+
+func NewSTDOut() ConsoleUI {
+	return &stdOut{
+		coloredId: make(map[string]string),
+	}
+}
+
+type stdOut struct {
+	coloredId map[string]string
+}
+
+func (s stdOut) ColoredId(acct ymlparser.Account) string {
+	coloredId, ok := s.coloredId[acct.ID()]
+	if !ok {
+		colorFunc := colors.DeterministicColorFunc(acct.AccountID)
+		coloredId := colorFunc("[Account: " + acct.ID() + "]")
+		s.coloredId[acct.ID()] = coloredId
+	}
+	return coloredId
+}
+
+// runCmd takes the command and acct and runs it while prepending the
+// coloredAccountID from stderr and stdout and printing it.
+func (s stdOut) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
+	stdoutPipe, err := cmd.StdoutPipe()
+	if err != nil {
+		return fmt.Errorf("[ERROR] %s %v", s.ColoredId(acct), err)
+	}
+	stdoutScanner := bufio.NewScanner(stdoutPipe)
+
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return fmt.Errorf("[ERROR] %s %v", s.ColoredId(acct), err)
+	}
+	stderrScanner := bufio.NewScanner(stderrPipe)
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("[ERROR] %s %v", s.ColoredId(acct), err)
+	}
+
+	var scannerWg sync.WaitGroup
+	scannerWg.Add(2)
+	scanF := func(scanner *bufio.Scanner, name string) {
+		defer scannerWg.Done()
+		for scanner.Scan() {
+			fmt.Printf("%s %s\n", s.ColoredId(acct), scanner.Text())
+		}
+		if err := scanner.Err(); err != nil {
+			fmt.Printf("[ERROR] %s %v\n", s.ColoredId(acct), err)
+			return
+		}
+	}
+
+	go scanF(stdoutScanner, "stdout")
+	go scanF(stderrScanner, "stderr")
+	scannerWg.Wait()
+
+	if err := cmd.Wait(); err != nil {
+		return fmt.Errorf("[ERROR] %s %v", s.ColoredId(acct), err)
+	}
+
+	return nil
+}
+
+func (s stdOut) Print(msg string, acct ymlparser.Account) {
+	fmt.Printf("%s %v\n", s.ColoredId(acct), msg)
+}
+
+func (s stdOut) PostProcess() {}

--- a/cmd/runner/tui.go
+++ b/cmd/runner/tui.go
@@ -1,0 +1,172 @@
+package runner
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os/exec"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/rivo/tview"
+	"github.com/santiago-labs/telophasecli/lib/ymlparser"
+)
+
+var tuiIndex atomic.Int64
+var tuiLock sync.Mutex
+
+type tui struct {
+	tails map[string]*func() string
+	index map[string]int
+	list  *tview.List
+	main  *tview.TextView
+	app   *tview.Application
+	tv    *tview.TextView
+	files map[string]io.Writer
+}
+
+func NewTUI() ConsoleUI {
+	app := tview.NewApplication()
+	tv := tview.NewTextView().SetDynamicColors(true)
+
+	main := tv.
+		SetTextAlign(tview.AlignLeft).SetScrollable(true).
+		SetChangedFunc(func() {
+			tv.ScrollToEnd()
+			app.Draw()
+		}).SetText("Starting CDK...")
+
+	return &tui{
+		list:  tview.NewList(),
+		app:   app,
+		main:  main,
+		tv:    tv,
+		index: make(map[string]int),
+		tails: make(map[string]*func() string),
+		files: make(map[string]io.Writer),
+	}
+}
+
+func (t tui) createIfNotExists(acct ymlparser.Account) {
+	var acctId = acct.ID()
+	if acctId == "" {
+		acctId = "Not yet provisioned"
+	}
+
+	tuiLock.Lock()
+	defer tuiLock.Unlock()
+	if _, ok := t.tails[acct.ID()]; ok {
+		return
+	}
+
+	idx := len(t.index)
+	t.index[acctId] = idx
+
+	t.list.AddItem(acctId, acct.AccountName, runeIndex(idx), func() {
+		currText := *t.tails[acctId]
+		// And we want to call this on repeat
+		tuiIndex.Swap(int64(idx))
+		tuiLock.Lock()
+		defer tuiLock.Unlock()
+		t.main.SetText(tview.TranslateANSI(currText()))
+	})
+
+	file, err := ioutil.TempFile("/tmp", acctId)
+	if err != nil {
+		panic(err)
+	}
+
+	setter := func() string {
+		bytes, err := ioutil.ReadFile(file.Name())
+		if err != nil {
+			fmt.Printf("ERR: %s \n", err)
+			return ""
+		}
+
+		return string(bytes)
+	}
+
+	t.tails[acct.ID()] = &setter
+	t.files[acct.ID()] = file
+}
+
+func (t tui) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
+	t.createIfNotExists(acct)
+	cmd.Stderr = t.files[acct.ID()]
+	cmd.Stdout = t.files[acct.ID()]
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	if err := cmd.Wait(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (t tui) PostProcess() {
+	t.list.AddItem("Quit", "Press to exit", 'q', func() {
+		t.app.Stop()
+	})
+
+	// Start index at 0 for the first account.
+	tuiIndex.Swap(0)
+
+	go t.liveTextSetter()
+
+	grid := tview.NewGrid().
+		SetColumns(-1, -3).
+		SetRows(-1).
+		SetBorders(true)
+
+	// Layout for screens wider than 100 cells.
+	grid.AddItem(t.list, 0, 0, 1, 1, 0, 100, false).
+		AddItem(t.main, 0, 1, 1, 1, 0, 100, false)
+
+	if err := t.app.SetRoot(grid, true).SetFocus(t.list).Run(); err != nil {
+		panic(err)
+	}
+
+}
+
+func (t tui) Print(msg string, acct ymlparser.Account) {
+	t.createIfNotExists(acct)
+	fmt.Fprint(t.files[acct.ID()], msg)
+}
+
+func runeIndex(i int) rune {
+	j := 0
+	for r := 'a'; r <= 'p'; r++ {
+		if j == i {
+			return r
+		}
+		j++
+	}
+
+	return 'z'
+}
+
+// liveTextSetter updates the current tui view with the current tail's text.
+func (t tui) liveTextSetter() {
+	for {
+		func() {
+			time.Sleep(200 * time.Millisecond)
+			tuiLock.Lock()
+			defer tuiLock.Unlock()
+			var tailfunc func() string
+			for key, val := range t.index {
+				if int64(val) == tuiIndex.Load() {
+					tailfunc = *t.tails[key]
+				}
+			}
+
+			curr := t.tv.GetText(true)
+			newText := tailfunc()
+			if newText != curr && newText != "" {
+				t.tv.SetText(tview.TranslateANSI(tailfunc()))
+			}
+		}()
+	}
+}

--- a/cmd/runner/tui.go
+++ b/cmd/runner/tui.go
@@ -48,7 +48,7 @@ func NewTUI() ConsoleUI {
 	}
 }
 
-func (t tui) createIfNotExists(acct ymlparser.Account) {
+func (t *tui) createIfNotExists(acct ymlparser.Account) {
 	var acctId = acct.ID()
 	if acctId == "" {
 		acctId = "Not yet provisioned"
@@ -91,7 +91,7 @@ func (t tui) createIfNotExists(acct ymlparser.Account) {
 	t.files[acct.ID()] = file
 }
 
-func (t tui) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
+func (t *tui) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
 	t.createIfNotExists(acct)
 	cmd.Stderr = t.files[acct.ID()]
 	cmd.Stdout = t.files[acct.ID()]
@@ -106,7 +106,7 @@ func (t tui) RunCmd(cmd *exec.Cmd, acct ymlparser.Account) error {
 	return nil
 }
 
-func (t tui) PostProcess() {
+func (t *tui) PostProcess() {
 	t.list.AddItem("Quit", "Press to exit", 'q', func() {
 		t.app.Stop()
 	})
@@ -149,7 +149,7 @@ func runeIndex(i int) rune {
 }
 
 // liveTextSetter updates the current tui view with the current tail's text.
-func (t tui) liveTextSetter() {
+func (t *tui) liveTextSetter() {
 	for {
 		func() {
 			time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
This is the first step of a larger refactor to merge the logic for org, SCP, and iac changes

This PR does two things
1. moves the logic for making org changes to the command (eg `diff.go`) logic.
2. Merges the tui and stdout into a single deploy path