### PR TITLE
run process in main thread for stdout.

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -31,11 +31,12 @@ var compileCmd = &cobra.Command{
 		var consoleUI runner.ConsoleUI
 		if useTUI {
 			consoleUI = runner.NewTUI()
+			go processOrgEndToEnd(consoleUI, resourceoperation.Deploy)
 		} else {
 			consoleUI = runner.NewSTDOut()
+			processOrgEndToEnd(consoleUI, resourceoperation.Deploy)
 		}
 
-		go processOrgEndToEnd(consoleUI, resourceoperation.Deploy)
 		consoleUI.Start()
 
 	},

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -23,11 +23,12 @@ var diffCmd = &cobra.Command{
 		var consoleUI runner.ConsoleUI
 		if useTUI {
 			consoleUI = runner.NewTUI()
+			go processOrgEndToEnd(consoleUI, resourceoperation.Diff)
 		} else {
 			consoleUI = runner.NewSTDOut()
+			processOrgEndToEnd(consoleUI, resourceoperation.Diff)
 		}
 
-		go processOrgEndToEnd(consoleUI, resourceoperation.Diff)
 		consoleUI.Start()
 	},
 }

--- a/cmd/provisionaccounts.go
+++ b/cmd/provisionaccounts.go
@@ -52,11 +52,11 @@ var accountProvision = &cobra.Command{
 		var consoleUI runner.ConsoleUI
 		if useTUI {
 			consoleUI = runner.NewTUI()
+			go processOrg(consoleUI, args[0])
 		} else {
 			consoleUI = runner.NewSTDOut()
+			processOrg(consoleUI, args[0])
 		}
-
-		go processOrg(consoleUI, args[0])
 		consoleUI.Start()
 
 	},
@@ -80,6 +80,7 @@ func processOrg(consoleUI runner.ConsoleUI, cmd string) {
 	if err != nil {
 		consoleUI.Print(fmt.Sprintf("error parsing organization: %s", err), *mgmtAcct)
 	}
+
 	if cmd == "diff" {
 		consoleUI.Print("Diffing AWS Organization", *mgmtAcct)
 		orgV2Diff(ctx, consoleUI, orgClient, rootAWSGroup, mgmtAcct, resourceoperation.Diff)
@@ -97,7 +98,7 @@ func processOrg(consoleUI runner.ConsoleUI, cmd string) {
 		}
 	}
 
-	consoleUI.Print("Done.", *mgmtAcct)
+	consoleUI.Print("Done.\n", *mgmtAcct)
 }
 
 func orgV2Diff(

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -74,4 +74,5 @@ func processOrgEndToEnd(consoleUI runner.ConsoleUI, cmd int) {
 	if len(scpOps) == 0 {
 		consoleUI.Print("No Service Control Policies to deploy.", *mgmtAcct)
 	}
+	consoleUI.Print("Done.\n", *mgmtAcct)
 }

--- a/resourceoperation/account.go
+++ b/resourceoperation/account.go
@@ -126,7 +126,7 @@ func (ao *accountOperation) ToString() string {
 	var templated string
 	if ao.Operation == Create {
 		printColor = "green"
-		templated = `(Create Account)
+		templated = "\n" + `(Create Account)
 +	Name: {{ .Account.AccountName }}
 +	Email: {{ .Account.Email }}
 +	Parent ID: {{ if .NewParent.ID }}{{ .NewParent.ID }}{{else}}<computed>{{end}}
@@ -134,7 +134,7 @@ func (ao *accountOperation) ToString() string {
 
 `
 	} else if ao.Operation == UpdateParent {
-		templated = `(Update Account Parent)
+		templated = "\n" + `(Update Account Parent)
 ID: {{ .Account.AccountID }}
 Name: {{ .Account.AccountName }}
 Email: {{ .Account.Email }}

--- a/resourceoperation/organization_unit.go
+++ b/resourceoperation/organization_unit.go
@@ -277,14 +277,14 @@ func (ou *organizationUnitOperation) ToString() string {
 	var templated string
 	if ou.Operation == Create {
 		printColor = "green"
-		templated = `(Create Organizational Unit)
+		templated = "\n" + `(Create Organizational Unit)
 +	Name: {{ .OrganizationUnit.Name }}
 +	Parent ID: {{ if .NewParent.ID }}{{ .NewParent.ID }}{{else}}<computed>{{end}}
 +	Parent Name: {{ .NewParent.Name }}
 
 `
 	} else if ou.Operation == UpdateParent {
-		templated = `(Update Organizational Unit Parent)
+		templated = "\n" + `(Update Organizational Unit Parent)
 ID: {{ .OrganizationUnit.ID }}
 Name: {{ .OrganizationUnit.Name }}
 ~	Parent ID: {{ .CurrentParent.ID }} -> {{ if .NewParent.ID }}{{ .NewParent.ID }}{{else}}<computed>{{end}}
@@ -292,7 +292,7 @@ Name: {{ .OrganizationUnit.Name }}
 
 `
 	} else if ou.Operation == Update {
-		templated = `(Update Organizational Unit)
+		templated = "\n" + `(Update Organizational Unit)
 ID: {{ .OrganizationUnit.ID }}
 ~	Name: {{ .OrganizationUnit.Name }} -> {{ .NewName }}
 


### PR DESCRIPTION
The change that moved the bulk of the logic for `diff`, `deploy`, and `account` into its own function  broke printing to stdout. That function should only be run in a gothread for `tui`