### PR TITLE
Delegated Admin

### DIFF
--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -385,7 +385,7 @@ func (c Client) FetchOUAndDescendents(ctx context.Context, ouID, mgmtAccountID s
 			Parent:      &ou,
 			AccountName: *providerAcct.Name,
 		}
-		if providerAcct.Id == &mgmtAccountID {
+		if *providerAcct.Id == mgmtAccountID {
 			acct.ManagementAccount = true
 		}
 		ou.Accounts = append(ou.Accounts, &acct)

--- a/resource/account.go
+++ b/resource/account.go
@@ -15,7 +15,8 @@ type Account struct {
 	Tags                   []string          `yaml:"Tags,omitempty"`
 	BaselineStacks         []Stack           `yaml:"Stacks,omitempty"`
 	ServiceControlPolicies []Stack           `yaml:"ServiceControlPolicies,omitempty"`
-	ManagementAccount      bool              `yaml:"ManagementAccount,omitempty"`
+	ManagementAccount      bool              `yaml:"-"`
+	DelegatedAdministrator bool              `yaml:"DelegatedAdministrator,omitempty"`
 	Parent                 *OrganizationUnit `yaml:"-"`
 }
 

--- a/resource/organization_unit.go
+++ b/resource/organization_unit.go
@@ -56,6 +56,28 @@ func (grp OrganizationUnit) AllDescendentAccounts() []*Account {
 	return accounts
 }
 
+// This should only be called from the Root OU.
+func (grp OrganizationUnit) DelegatedAdministrator() *Account {
+	for _, acct := range grp.AllDescendentAccounts() {
+		if acct.DelegatedAdministrator {
+			return acct
+		}
+	}
+
+	return nil
+}
+
+// This should only be called from the Root OU.
+func (grp OrganizationUnit) ManagementAccount() *Account {
+	for _, acct := range grp.AllDescendentAccounts() {
+		if acct.ManagementAccount {
+			return acct
+		}
+	}
+
+	return nil
+}
+
 func (grp OrganizationUnit) AllDescendentOUs() []*OrganizationUnit {
 	var OUs []*OrganizationUnit
 	OUs = append(OUs, grp.ChildOUs...)

--- a/tests/end2end_test.go
+++ b/tests/end2end_test.go
@@ -48,8 +48,9 @@ Organization:
 			},
 			Accounts: []*resource.Account{
 				{
-					AccountName: "master",
-					Email:       "master@example.com",
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
 				},
 			},
 		},
@@ -100,8 +101,9 @@ Organization:
 			},
 			Accounts: []*resource.Account{
 				{
-					AccountName: "master",
-					Email:       "master@example.com",
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
 				},
 			},
 		},
@@ -123,8 +125,9 @@ Organization:
 			OUName: "root",
 			Accounts: []*resource.Account{
 				{
-					AccountName: "master",
-					Email:       "master@example.com",
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
 				},
 				{
 					AccountName: "test1",
@@ -241,8 +244,9 @@ Organization:
 			},
 			Accounts: []*resource.Account{
 				{
-					AccountName: "master",
-					Email:       "master@example.com",
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
 				},
 				{
 					AccountName: "test8",
@@ -346,8 +350,9 @@ Organization:
 			},
 			Accounts: []*resource.Account{
 				{
-					AccountName: "master",
-					Email:       "master@example.com",
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
 				},
 			},
 		},
@@ -381,7 +386,7 @@ func TestEndToEnd(t *testing.T) {
 			assert.NoError(t, err, "Error fetching root OU ID")
 			test.OrgInitialState.OUID = &rootId
 
-			ymlparser.HydrateParsedOrg(test.OrgInitialState)
+			ymlparser.HydrateParsedOrg(ctx, test.OrgInitialState)
 			orgOps := resourceoperation.CollectOrganizationUnitOps(
 				ctx, consoleUI, orgClient, mgmtAcct, test.OrgInitialState, resourceoperation.Deploy,
 			)
@@ -392,7 +397,7 @@ func TestEndToEnd(t *testing.T) {
 				}
 			}
 
-			fetchedOrg, err := orgClient.FetchOUAndDescendents(ctx, rootId, "000000000000")
+			fetchedOrg, err := orgClient.FetchOUAndDescendents(ctx, rootId, mgmtAcct.AccountID)
 			assert.NoError(t, err, "Failed to fetch rootOU")
 
 			compareOrganizationUnits(t, test.OrgInitialState, &fetchedOrg)
@@ -401,14 +406,14 @@ func TestEndToEnd(t *testing.T) {
 		err = ioutil.WriteFile("organization.yml", []byte(test.OrgYaml), 0644)
 		assert.NoError(t, err, "Failed to write organization.yml")
 
-		parsedOrg, err := ymlparser.ParseOrganizationV2("organization.yml")
+		parsedOrg, err := ymlparser.ParseOrganizationV2(ctx, "organization.yml")
 		assert.NoError(t, err, "Failed to parse organization.yml")
 
 		compareOrganizationUnits(t, test.Expected, parsedOrg)
 
 		cmd.ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy)
 
-		fetchedOrg, err := orgClient.FetchOUAndDescendents(ctx, rootId, "000000000000")
+		fetchedOrg, err := orgClient.FetchOUAndDescendents(ctx, rootId, mgmtAcct.AccountID)
 		assert.NoError(t, err, "Failed to fetch rootOU")
 
 		compareOrganizationUnits(t, test.Expected, &fetchedOrg)


### PR DESCRIPTION
This change add support for deploying SCP changes from a [delegated administrator](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_delegate_policies.html). I fixed two bugs along the way
1. `FetchOUAndDescendents` was not setting the `ManagementAccount` flag becuase pointer addresses were compared instead of the values (lol)
2. `ManagementAccount` flag was not set during yml parsing