### PR TITLE
pass account id into cdk context

### DIFF
--- a/examples/cdk/tf-s3-backend/app.go
+++ b/examples/cdk/tf-s3-backend/app.go
@@ -2,35 +2,14 @@ package main
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/aws/aws-cdk-go/awscdk"
 	"github.com/aws/aws-cdk-go/awscdk/awss3"
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/aws/jsii-runtime-go"
 )
 
 type TerraformStateBucketStackProps struct {
 	awscdk.StackProps
-}
-
-func fetchAccountID() string {
-	cfg := aws.NewConfig()
-	if os.Getenv("LOCALSTACK") != "" {
-		cfg.Endpoint = aws.String("http://localhost:4566")
-	}
-	sess := session.Must(session.NewSession(
-		cfg,
-	))
-	svc := sts.New(sess)
-	result, err := svc.GetCallerIdentity(&sts.GetCallerIdentityInput{})
-	if err != nil {
-		panic(fmt.Sprintf("Failed to get caller identity: %s", err))
-	}
-
-	return *result.Account
 }
 
 func NewTerraformStateBucketStack(scope awscdk.Construct, id string, props *TerraformStateBucketStackProps) awscdk.Stack {
@@ -40,9 +19,10 @@ func NewTerraformStateBucketStack(scope awscdk.Construct, id string, props *Terr
 	}
 	stack := awscdk.NewStack(scope, &id, &sprops)
 
+	accountId := stack.Node().TryGetContext(jsii.String("telophaseAccountId")).(string)
 	awss3.NewBucket(stack, jsii.String("TerraformStateBucket"), &awss3.BucketProps{
 		Versioned:  jsii.Bool(true),
-		BucketName: jsii.String(fmt.Sprintf("tfstate-%s", fetchAccountID())),
+		BucketName: jsii.String(fmt.Sprintf("tfstate-%s", accountId)),
 	})
 
 	return stack

--- a/examples/cdk/tf-s3-backend/go.mod
+++ b/examples/cdk/tf-s3-backend/go.mod
@@ -9,10 +9,8 @@ require (
 
 require (
 	github.com/Masterminds/semver/v3 v3.2.1 // indirect
-	github.com/aws/aws-sdk-go v1.48.1 // indirect
 	github.com/aws/constructs-go/constructs/v3 v3.4.232 // indirect
 	github.com/fatih/color v1.15.0 // indirect
-	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.19 // indirect
 	github.com/yuin/goldmark v1.4.13 // indirect

--- a/resourceoperation/cdk.go
+++ b/resourceoperation/cdk.go
@@ -84,6 +84,7 @@ func (co *cdkOperation) Call(ctx context.Context) error {
 		cdkArgs = []string{
 			"diff",
 			"--context", fmt.Sprintf("telophaseAccountName=%s", co.Account.AccountName),
+			"--context", fmt.Sprintf("telophaseAccountId=%s", co.Account.AccountID),
 			"--output", cdk.TmpPath(*co.Account, co.Stack.Path),
 		}
 	} else if co.Operation == Deploy {
@@ -91,6 +92,7 @@ func (co *cdkOperation) Call(ctx context.Context) error {
 	}
 
 	cdkArgs = append(cdkArgs, "--context", fmt.Sprintf("telophaseAccountName=%s", co.Account.AccountName))
+	cdkArgs = append(cdkArgs, "--context", fmt.Sprintf("telophaseAccountId=%s", co.Account.AccountID))
 	if co.Stack.Name == "" {
 		cdkArgs = append(cdkArgs, "--all")
 	} else {
@@ -126,6 +128,7 @@ func bootstrapCDK(result *sts.AssumeRoleOutput, region string, acct resource.Acc
 		"bootstrap",
 		fmt.Sprintf("aws://%s/%s", acct.AccountID, region),
 		"--context", fmt.Sprintf("telophaseAccountName=%s", acct.AccountName),
+		"--context", fmt.Sprintf("telophaseAccountId=%s", acct.AccountID),
 		"--output", cdk.TmpPath(acct, stack.Path),
 	}
 
@@ -145,6 +148,7 @@ func synthCDK(result *sts.AssumeRoleOutput, acct resource.Account, stack resourc
 	cdkArgs := []string{
 		"synth",
 		"--context", fmt.Sprintf("telophaseAccountName=%s", acct.AccountName),
+		"--context", fmt.Sprintf("telophaseAccountId=%s", acct.AccountID),
 		"--output", cdk.TmpPath(acct, stack.Path),
 	}
 


### PR DESCRIPTION
`telophaseAccountId` is now available in cdk context to reference your Account ID. 

You can fetch it in your cdk code with `accountId := stack.Node().TryGetContext(jsii.String("telophaseAccountId")).(string)`