### PR TITLE
Split SCP, Organization, and Stacks Commands

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -8,22 +8,24 @@ import (
 )
 
 var (
-	tag    string
-	stacks string
+	tag     string
+	targets string
+	stacks  string
 
 	// TUI
 	useTUI bool
 )
 
 func init() {
-	rootCmd.AddCommand(compileCmd)
-	compileCmd.Flags().StringVar(&stacks, "stacks", "", "Filter stacks to deploy")
-	compileCmd.Flags().StringVar(&tag, "tag", "", "Filter accounts and organization units to deploy")
-	compileCmd.Flags().StringVar(&orgFile, "org", "organization.yml", "Path to the organization.yml file")
-	compileCmd.Flags().BoolVar(&useTUI, "tui", false, "use the TUI for deploy")
+	rootCmd.AddCommand(deployCmd)
+	deployCmd.Flags().StringVar(&stacks, "stacks", "", "Filter stacks to deploy")
+	deployCmd.Flags().StringVar(&tag, "tag", "", "Filter accounts and organization units to deploy")
+	deployCmd.Flags().StringVar(&targets, "targets", "", "Filter resource types to deploy. Options: organization, scp, baseline")
+	deployCmd.Flags().StringVar(&orgFile, "org", "organization.yml", "Path to the organization.yml file")
+	deployCmd.Flags().BoolVar(&useTUI, "tui", false, "use the TUI for deploy")
 }
 
-var compileCmd = &cobra.Command{
+var deployCmd = &cobra.Command{
 	Use:   "deploy",
 	Short: "deploy - Deploy a CDK and/or TF stacks to your AWS account(s). Accounts in organization.yml will be created if they do not exist.",
 	Run: func(cmd *cobra.Command, args []string) {
@@ -31,10 +33,10 @@ var compileCmd = &cobra.Command{
 		var consoleUI runner.ConsoleUI
 		if useTUI {
 			consoleUI = runner.NewTUI()
-			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy)
+			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, targets)
 		} else {
 			consoleUI = runner.NewSTDOut()
-			ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy)
+			ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, targets)
 		}
 
 		consoleUI.Start()

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -11,6 +11,7 @@ func init() {
 	rootCmd.AddCommand(diffCmd)
 	diffCmd.Flags().StringVar(&stacks, "stacks", "", "Filter stacks to deploy")
 	diffCmd.Flags().StringVar(&tag, "tag", "", "Filter accounts and organization units to deploy.")
+	diffCmd.Flags().StringVar(&targets, "targets", "", "Filter resource types to deploy. Options: organization, scp, baseline")
 	diffCmd.Flags().StringVar(&orgFile, "org", "organization.yml", "Path to the organization.yml file")
 	diffCmd.Flags().BoolVar(&useTUI, "tui", false, "use the TUI for diff")
 }
@@ -23,10 +24,10 @@ var diffCmd = &cobra.Command{
 		var consoleUI runner.ConsoleUI
 		if useTUI {
 			consoleUI = runner.NewTUI()
-			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff)
+			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, targets)
 		} else {
 			consoleUI = runner.NewSTDOut()
-			ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff)
+			ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, targets)
 		}
 
 		consoleUI.Start()

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"fmt"
+	"strings"
+
 	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/resourceoperation"
 
@@ -11,7 +14,7 @@ func init() {
 	rootCmd.AddCommand(diffCmd)
 	diffCmd.Flags().StringVar(&stacks, "stacks", "", "Filter stacks to deploy")
 	diffCmd.Flags().StringVar(&tag, "tag", "", "Filter accounts and organization units to deploy.")
-	diffCmd.Flags().StringVar(&targets, "targets", "", "Filter resource types to deploy. Options: organization, scp, baseline")
+	diffCmd.Flags().StringVar(&targets, "targets", "", "Filter resource types to deploy. Options: organization, scp, stacks")
 	diffCmd.Flags().StringVar(&orgFile, "org", "organization.yml", "Path to the organization.yml file")
 	diffCmd.Flags().BoolVar(&useTUI, "tui", false, "use the TUI for diff")
 }
@@ -21,13 +24,17 @@ var diffCmd = &cobra.Command{
 	Short: "diff - Show accounts to create/update and CDK and/or TF changes for each account.",
 	Run: func(cmd *cobra.Command, args []string) {
 
+		if err := validateTargets(); err != nil {
+			fmt.Println(err)
+			return
+		}
 		var consoleUI runner.ConsoleUI
 		if useTUI {
 			consoleUI = runner.NewTUI()
-			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, targets)
+			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, strings.Split(targets, ","))
 		} else {
 			consoleUI = runner.NewSTDOut()
-			ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, targets)
+			ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, strings.Split(targets, ","))
 		}
 
 		consoleUI.Start()

--- a/resourceoperation/scp.go
+++ b/resourceoperation/scp.go
@@ -31,6 +31,10 @@ func CollectSCPOps(
 
 	var ops []ResourceOperation
 	for _, ou := range rootOU.AllDescendentOUs() {
+		if ou.OUID == nil {
+			consoleUI.Print(fmt.Sprintf("Skipping OU because it is not yet created: %s", ou.OUName), *mgmtAcct)
+			continue
+		}
 		for _, scp := range ou.ServiceControlPolicies {
 			ops = append(ops, NewSCPOperation(
 				consoleUI,
@@ -44,6 +48,10 @@ func CollectSCPOps(
 	}
 
 	for _, acct := range rootOU.AllDescendentAccounts() {
+		if acct.AccountID == "" {
+			consoleUI.Print(fmt.Sprintf("Skipping Account because it is not yet created: %s", acct.AccountName), *mgmtAcct)
+			continue
+		}
 		for _, scp := range acct.ServiceControlPolicies {
 			ops = append(ops, NewSCPOperation(
 				consoleUI,

--- a/setup.sh
+++ b/setup.sh
@@ -17,6 +17,8 @@ elif [ "$(uname)" = "Linux" ]; then
     if [ -f /etc/debian_version ]; then
         echo "Debian-based Linux detected. Installing packages with apt."
         sudo apt update && sudo apt install -y awscli
+        pip3 install awscli-local
+        pip3 install terraform-local
         sudo snap install terraform --classic
         curl -Lo localstack-cli-3.3.0-linux-amd64-onefile.tar.gz https://github.com/localstack/localstack-cli/releases/download/v3.3.0/localstack-cli-3.3.0-linux-amd64-onefile.tar.gz
         sudo tar xvzf localstack-cli-3.3.0-linux-*-onefile.tar.gz -C /usr/local/bin

--- a/setup.sh
+++ b/setup.sh
@@ -12,7 +12,7 @@ print_green() {
 
 if command -v brew &> /dev/null; then
     echo "Brew is installed, proceeding with awscli and terraform installation."
-    brew install awscli terraform localstack/tap/localstack-cli
+    brew install awscli awscli-local terraform terraform-local localstack/tap/localstack-cli
 elif [ "$(uname)" = "Linux" ]; then
     if [ -f /etc/debian_version ]; then
         echo "Debian-based Linux detected. Installing packages with apt."

--- a/tests/end2end_test.go
+++ b/tests/end2end_test.go
@@ -24,350 +24,537 @@ type E2ETestCase struct {
 	Name              string
 	OrgInitialState   *resource.OrganizationUnit
 	OrgYaml           string
-	Expected          *resource.OrganizationUnit
-	Targets           string
+	FetchExpected     *resource.OrganizationUnit
+	ParseExpected     *resource.OrganizationUnit
+	Targets           []string
 	ExpectedResources func(t *testing.T)
 }
 
 var tests = []E2ETestCase{
-	// 	{
-	// 		Name: "Test that we can create OUs",
-	// 		OrgYaml: `
-	// Organization:
-	//     Name: root
-	//     OrganizationUnits:
-	//       - Name: ProductionTenants
-	//       - Name: Development
-	//     Accounts:
-	//       - AccountName: master
-	//         Email: master@example.com
-	// `,
-	// 		Expected: &resource.OrganizationUnit{
-	// 			OUName: "root",
-	// 			ChildOUs: []*resource.OrganizationUnit{
-	// 				{
-	// 					OUName: "ProductionTenants",
-	// 				},
-	// 				{
-	// 					OUName: "Development",
-	// 				},
-	// 			},
-	// 			Accounts: []*resource.Account{
-	// 				{
-	// 					AccountName:       "master",
-	// 					Email:             "master@example.com",
-	// 					ManagementAccount: true,
-	// 				},
-	// 			},
-	// 		},
-	// 		ExpectedResources: func(*testing.T) {},
-	// 	},
-	// 	{
-	// 		Name: "Test that we can create nested OUs",
-	// 		OrgYaml: `
-	// Organization:
-	//     Name: root
-	//     OrganizationUnits:
-	//       - Name: ProductionTenants
-	//         OrganizationUnits:
-	//           - Name: ProductionEU
-	//           - Name: ProductionUS
-	//       - Name: Development
-	//         OrganizationUnits:
-	//           - Name: DevEU
-	//           - Name: DevUS
-	//     Accounts:
-	//       - AccountName: master
-	//         Email: master@example.com
-	// `,
-	// 		Expected: &resource.OrganizationUnit{
-	// 			OUName: "root",
-	// 			ChildOUs: []*resource.OrganizationUnit{
-	// 				{
-	// 					OUName: "ProductionTenants",
-	// 					ChildOUs: []*resource.OrganizationUnit{
-	// 						{
-	// 							OUName: "ProductionEU",
-	// 						},
-	// 						{
-	// 							OUName: "ProductionUS",
-	// 						},
-	// 					},
-	// 				},
-	// 				{
-	// 					OUName: "Development",
-	// 					ChildOUs: []*resource.OrganizationUnit{
-	// 						{
-	// 							OUName: "DevEU",
-	// 						},
-	// 						{
-	// 							OUName: "DevUS",
-	// 						},
-	// 					},
-	// 				},
-	// 			},
-	// 			Accounts: []*resource.Account{
-	// 				{
-	// 					AccountName:       "master",
-	// 					Email:             "master@example.com",
-	// 					ManagementAccount: true,
-	// 				},
-	// 			},
-	// 		},
-	// 		ExpectedResources: func(*testing.T) {},
-	// 	},
-	// 	{
-	// 		Name: "Test that we can create accounts",
-	// 		OrgYaml: `
-	// Organization:
-	//   Name: root
-	//   Accounts:
-	//     - AccountName: master
-	//       Email: master@example.com
-	//     - AccountName: test1
-	//       Email: test1@example.com
-	//     - AccountName: test2
-	//       Email: test2@example.com
-	// `,
-	// 		Expected: &resource.OrganizationUnit{
-	// 			OUName: "root",
-	// 			Accounts: []*resource.Account{
-	// 				{
-	// 					AccountName:       "master",
-	// 					Email:             "master@example.com",
-	// 					ManagementAccount: true,
-	// 				},
-	// 				{
-	// 					AccountName: "test1",
-	// 					Email:       "test1@example.com",
-	// 				},
-	// 				{
-	// 					AccountName: "test2",
-	// 					Email:       "test2@example.com",
-	// 				},
-	// 			},
-	// 		},
-	// 		ExpectedResources: func(*testing.T) {},
-	// 	},
-	// 	{
-	// 		Name: "Test that we can create accounts in OUs",
-	// 		OrgYaml: `
-	// Organization:
-	//   Name: root
-	//   OrganizationUnits:
-	//     - Name: ProductionTenants
-	//       Accounts:
-	//         - AccountName: test1
-	//           Email: test1@example.com
-	//       OrganizationUnits:
-	//         - Name: ProductionEU
-	//         - Name: ProductionUS
-	//           Accounts:
-	//             - AccountName: test2
-	//               Email: test2@example.com
-	//     - Name: Development
-	//       OrganizationUnits:
-	//         - Name: DevEU
-	//           Accounts:
-	//             - AccountName: test3
-	//               Email: test3@example.com
-	//             - AccountName: test4
-	//               Email: test4@example.com
-	//             - AccountName: test5
-	//               Email: test5@example.com
-	//         - Name: DevUS
-	//           Accounts:
-	//             - AccountName: test6
-	//               Email: test6@example.com
-	//             - AccountName: test7
-	//               Email: test7@example.com
-	//   Accounts:
-	//     - AccountName: master
-	//       Email: master@example.com
-	//     - AccountName: test8
-	//       Email: test8@example.com
-	//     - AccountName: test9
-	//       Email: test9@example.com
-	// `,
-	// 		Expected: &resource.OrganizationUnit{
-	// 			OUName: "root",
-	// 			ChildOUs: []*resource.OrganizationUnit{
-	// 				{
-	// 					OUName: "ProductionTenants",
-	// 					Accounts: []*resource.Account{
-	// 						{
-	// 							AccountName: "test1",
-	// 							Email:       "test1@example.com",
-	// 						},
-	// 					},
-	// 					ChildOUs: []*resource.OrganizationUnit{
-	// 						{
-	// 							OUName: "ProductionEU",
-	// 						},
-	// 						{
-	// 							OUName: "ProductionUS",
-	// 							Accounts: []*resource.Account{
-	// 								{
-	// 									AccountName: "test2",
-	// 									Email:       "test2@example.com",
-	// 								},
-	// 							},
-	// 						},
-	// 					},
-	// 				},
-	// 				{
-	// 					OUName: "Development",
-	// 					ChildOUs: []*resource.OrganizationUnit{
-	// 						{
-	// 							OUName: "DevEU",
-	// 							Accounts: []*resource.Account{
-	// 								{
-	// 									AccountName: "test3",
-	// 									Email:       "test3@example.com",
-	// 								},
-	// 								{
-	// 									AccountName: "test4",
-	// 									Email:       "test4@example.com",
-	// 								},
-	// 								{
-	// 									AccountName: "test5",
-	// 									Email:       "test5@example.com",
-	// 								},
-	// 							},
-	// 						},
-	// 						{
-	// 							OUName: "DevUS",
-	// 							Accounts: []*resource.Account{
-	// 								{
-	// 									AccountName: "test6",
-	// 									Email:       "test6@example.com",
-	// 								},
-	// 								{
-	// 									AccountName: "test7",
-	// 									Email:       "test7@example.com",
-	// 								},
-	// 							},
-	// 						},
-	// 					},
-	// 				},
-	// 			},
-	// 			Accounts: []*resource.Account{
-	// 				{
-	// 					AccountName:       "master",
-	// 					Email:             "master@example.com",
-	// 					ManagementAccount: true,
-	// 				},
-	// 				{
-	// 					AccountName: "test8",
-	// 					Email:       "test8@example.com",
-	// 				},
-	// 				{
-	// 					AccountName: "test9",
-	// 					Email:       "test9@example.com",
-	// 				},
-	// 			},
-	// 		},
-	// 		ExpectedResources: func(*testing.T) {},
-	// 	},
-	// 	{
-	// 		Name: "Test that we can move Accounts between OUs",
-	// 		OrgInitialState: &resource.OrganizationUnit{
-	// 			OUName: "root",
-	// 			ChildOUs: []*resource.OrganizationUnit{
-	// 				{
-	// 					OUName: "US Engineers",
-	// 					Accounts: []*resource.Account{
-	// 						{
-	// 							AccountName: "Engineer A",
-	// 							Email:       "engineerA@example.com",
-	// 						},
-	// 						{
-	// 							AccountName: "Engineer B",
-	// 							Email:       "engineerB@example.com",
-	// 						},
-	// 					},
-	// 				},
-	// 				{
-	// 					OUName: "EU Engineers",
-	// 					Accounts: []*resource.Account{
-	// 						{
-	// 							AccountName: "Engineer C",
-	// 							Email:       "engineerC@example.com",
-	// 						},
-	// 						{
-	// 							AccountName: "Engineer D",
-	// 							Email:       "engineerD@example.com",
-	// 						},
-	// 					},
-	// 				},
-	// 			},
-	// 			Accounts: []*resource.Account{
-	// 				{
-	// 					AccountName: "master",
-	// 					Email:       "master@example.com",
-	// 				},
-	// 			},
-	// 		},
-	// 		OrgYaml: `
-	// Organization:
-	//     Name: root
-	//     OrganizationUnits:
-	//       - Name: US Engineers
-	//         Accounts:
-	//           - AccountName: Engineer A
-	//             Email: engineerA@example.com
-	//       - Name: EU Engineers
-	//         Accounts:
-	//           - AccountName: Engineer C
-	//             Email: engineerC@example.com
-	//           - AccountName: Engineer D
-	//             Email: engineerD@example.com
-	//           - AccountName: Engineer B
-	//             Email: engineerB@example.com
-	//     Accounts:
-	//       - AccountName: master
-	//         Email: master@example.com
-	// `,
-	// 		Expected: &resource.OrganizationUnit{
-	// 			OUName: "root",
-	// 			ChildOUs: []*resource.OrganizationUnit{
-	// 				{
-	// 					OUName: "US Engineers",
-	// 					Accounts: []*resource.Account{
-	// 						{
-	// 							AccountName: "Engineer A",
-	// 							Email:       "engineerA@example.com",
-	// 						},
-	// 					},
-	// 				},
-	// 				{
-	// 					OUName: "EU Engineers",
-	// 					Accounts: []*resource.Account{
-	// 						{
-	// 							AccountName: "Engineer B",
-	// 							Email:       "engineerB@example.com",
-	// 						},
-	// 						{
-	// 							AccountName: "Engineer C",
-	// 							Email:       "engineerC@example.com",
-	// 						},
-	// 						{
-	// 							AccountName: "Engineer D",
-	// 							Email:       "engineerD@example.com",
-	// 						},
-	// 					},
-	// 				},
-	// 			},
-	// 			Accounts: []*resource.Account{
-	// 				{
-	// 					AccountName:       "master",
-	// 					Email:             "master@example.com",
-	// 					ManagementAccount: true,
-	// 				},
-	// 			},
-	// 		},
-	// 		ExpectedResources: func(*testing.T) {},
-	// 	},
+	{
+		Name: "Test that we can create OUs",
+		OrgYaml: `
+Organization:
+    Name: root
+    OrganizationUnits:
+      - Name: ProductionTenants
+      - Name: Development
+    Accounts:
+      - AccountName: master
+        Email: master@example.com
+`,
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+				},
+				{
+					OUName: "Development",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+				},
+				{
+					OUName: "Development",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ExpectedResources: func(*testing.T) {},
+	},
+	{
+		Name: "Test that we can create nested OUs",
+		OrgYaml: `
+Organization:
+    Name: root
+    OrganizationUnits:
+      - Name: ProductionTenants
+        OrganizationUnits:
+          - Name: ProductionEU
+          - Name: ProductionUS
+      - Name: Development
+        OrganizationUnits:
+          - Name: DevEU
+          - Name: DevUS
+    Accounts:
+      - AccountName: master
+        Email: master@example.com
+`,
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "ProductionEU",
+						},
+						{
+							OUName: "ProductionUS",
+						},
+					},
+				},
+				{
+					OUName: "Development",
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "DevEU",
+						},
+						{
+							OUName: "DevUS",
+						},
+					},
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "ProductionEU",
+						},
+						{
+							OUName: "ProductionUS",
+						},
+					},
+				},
+				{
+					OUName: "Development",
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "DevEU",
+						},
+						{
+							OUName: "DevUS",
+						},
+					},
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ExpectedResources: func(*testing.T) {},
+	},
+	{
+		Name: "Test that we can create accounts",
+		OrgYaml: `
+Organization:
+  Name: root
+  Accounts:
+    - AccountName: master
+      Email: master@example.com
+    - AccountName: test1
+      Email: test1@example.com
+    - AccountName: test2
+      Email: test2@example.com
+`,
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+				{
+					AccountName: "test1",
+					Email:       "test1@example.com",
+				},
+				{
+					AccountName: "test2",
+					Email:       "test2@example.com",
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+				{
+					AccountName: "test1",
+					Email:       "test1@example.com",
+				},
+				{
+					AccountName: "test2",
+					Email:       "test2@example.com",
+				},
+			},
+		},
+		ExpectedResources: func(*testing.T) {},
+	},
+	{
+		Name: "Test that we can create accounts in OUs",
+		OrgYaml: `
+Organization:
+  Name: root
+  OrganizationUnits:
+    - Name: ProductionTenants
+      Accounts:
+        - AccountName: test1
+          Email: test1@example.com
+      OrganizationUnits:
+        - Name: ProductionEU
+        - Name: ProductionUS
+          Accounts:
+            - AccountName: test2
+              Email: test2@example.com
+    - Name: Development
+      OrganizationUnits:
+        - Name: DevEU
+          Accounts:
+            - AccountName: test3
+              Email: test3@example.com
+            - AccountName: test4
+              Email: test4@example.com
+            - AccountName: test5
+              Email: test5@example.com
+        - Name: DevUS
+          Accounts:
+            - AccountName: test6
+              Email: test6@example.com
+            - AccountName: test7
+              Email: test7@example.com
+  Accounts:
+    - AccountName: master
+      Email: master@example.com
+    - AccountName: test8
+      Email: test8@example.com
+    - AccountName: test9
+      Email: test9@example.com
+`,
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "test1",
+							Email:       "test1@example.com",
+						},
+					},
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "ProductionEU",
+						},
+						{
+							OUName: "ProductionUS",
+							Accounts: []*resource.Account{
+								{
+									AccountName: "test2",
+									Email:       "test2@example.com",
+								},
+							},
+						},
+					},
+				},
+				{
+					OUName: "Development",
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "DevEU",
+							Accounts: []*resource.Account{
+								{
+									AccountName: "test3",
+									Email:       "test3@example.com",
+								},
+								{
+									AccountName: "test4",
+									Email:       "test4@example.com",
+								},
+								{
+									AccountName: "test5",
+									Email:       "test5@example.com",
+								},
+							},
+						},
+						{
+							OUName: "DevUS",
+							Accounts: []*resource.Account{
+								{
+									AccountName: "test6",
+									Email:       "test6@example.com",
+								},
+								{
+									AccountName: "test7",
+									Email:       "test7@example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+				{
+					AccountName: "test8",
+					Email:       "test8@example.com",
+				},
+				{
+					AccountName: "test9",
+					Email:       "test9@example.com",
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "test1",
+							Email:       "test1@example.com",
+						},
+					},
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "ProductionEU",
+						},
+						{
+							OUName: "ProductionUS",
+							Accounts: []*resource.Account{
+								{
+									AccountName: "test2",
+									Email:       "test2@example.com",
+								},
+							},
+						},
+					},
+				},
+				{
+					OUName: "Development",
+					ChildOUs: []*resource.OrganizationUnit{
+						{
+							OUName: "DevEU",
+							Accounts: []*resource.Account{
+								{
+									AccountName: "test3",
+									Email:       "test3@example.com",
+								},
+								{
+									AccountName: "test4",
+									Email:       "test4@example.com",
+								},
+								{
+									AccountName: "test5",
+									Email:       "test5@example.com",
+								},
+							},
+						},
+						{
+							OUName: "DevUS",
+							Accounts: []*resource.Account{
+								{
+									AccountName: "test6",
+									Email:       "test6@example.com",
+								},
+								{
+									AccountName: "test7",
+									Email:       "test7@example.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+				{
+					AccountName: "test8",
+					Email:       "test8@example.com",
+				},
+				{
+					AccountName: "test9",
+					Email:       "test9@example.com",
+				},
+			},
+		},
+		ExpectedResources: func(*testing.T) {},
+	},
+	{
+		Name: "Test that we can move Accounts between OUs",
+		OrgInitialState: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "US Engineers",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "Engineer A",
+							Email:       "engineerA@example.com",
+						},
+						{
+							AccountName: "Engineer B",
+							Email:       "engineerB@example.com",
+						},
+					},
+				},
+				{
+					OUName: "EU Engineers",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "Engineer C",
+							Email:       "engineerC@example.com",
+						},
+						{
+							AccountName: "Engineer D",
+							Email:       "engineerD@example.com",
+						},
+					},
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName: "master",
+					Email:       "master@example.com",
+				},
+			},
+		},
+		OrgYaml: `
+Organization:
+    Name: root
+    OrganizationUnits:
+      - Name: US Engineers
+        Accounts:
+          - AccountName: Engineer A
+            Email: engineerA@example.com
+      - Name: EU Engineers
+        Accounts:
+          - AccountName: Engineer C
+            Email: engineerC@example.com
+          - AccountName: Engineer D
+            Email: engineerD@example.com
+          - AccountName: Engineer B
+            Email: engineerB@example.com
+    Accounts:
+      - AccountName: master
+        Email: master@example.com
+`,
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "US Engineers",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "Engineer A",
+							Email:       "engineerA@example.com",
+						},
+					},
+				},
+				{
+					OUName: "EU Engineers",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "Engineer B",
+							Email:       "engineerB@example.com",
+						},
+						{
+							AccountName: "Engineer C",
+							Email:       "engineerC@example.com",
+						},
+						{
+							AccountName: "Engineer D",
+							Email:       "engineerD@example.com",
+						},
+					},
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "US Engineers",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "Engineer A",
+							Email:       "engineerA@example.com",
+						},
+					},
+				},
+				{
+					OUName: "EU Engineers",
+					Accounts: []*resource.Account{
+						{
+							AccountName: "Engineer B",
+							Email:       "engineerB@example.com",
+						},
+						{
+							AccountName: "Engineer C",
+							Email:       "engineerC@example.com",
+						},
+						{
+							AccountName: "Engineer D",
+							Email:       "engineerD@example.com",
+						},
+					},
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ExpectedResources: func(*testing.T) {},
+	},
 	{
 		Name: "Test that we can apply SCPs",
 		OrgYaml: `
@@ -383,7 +570,31 @@ Organization:
       - AccountName: master
         Email: master@example.com
 `,
-		Expected: &resource.OrganizationUnit{
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					ServiceControlPolicies: []resource.Stack{
+						{
+							Type: "Terraform",
+							Path: "tf/scp-test",
+						},
+					},
+				},
+				{
+					OUName: "Development",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
 			OUName: "root",
 			ChildOUs: []*resource.OrganizationUnit{
 				{
@@ -481,7 +692,23 @@ Organization:
       - AccountName: master
         Email: master@example.com
 `,
-		Expected: &resource.OrganizationUnit{
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			BaselineStacks: []resource.Stack{
+				{
+					Type: "Terraform",
+					Path: "tf/s3-test",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
 			OUName: "root",
 			BaselineStacks: []resource.Stack{
 				{
@@ -542,7 +769,38 @@ Organization:
       - AccountName: test
         Email: test@example.com
 `,
-		Expected: &resource.OrganizationUnit{
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					ServiceControlPolicies: []resource.Stack{
+						{
+							Type: "Terraform",
+							Path: "tf/scp-test",
+						},
+					},
+				},
+			},
+			BaselineStacks: []resource.Stack{
+				{
+					Type: "Terraform",
+					Path: "tf/s3-test",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+				{
+					AccountName: "test",
+					Email:       "test@example.com",
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
 			OUName: "root",
 			ChildOUs: []*resource.OrganizationUnit{
 				{
@@ -635,12 +893,266 @@ Organization:
 				t.Fatalf("Failed to list policies for 'ProductionTenants': %v", err)
 			}
 
-			if len(listPoliciesOutput.Policies) > 0 {
-				t.Fatalf("Policies found on OU: %v", listPoliciesOutput.Policies)
+			if len(listPoliciesOutput.Policies) > 1 {
+				t.Fatalf("Unexpected policies found on OU: %v", listPoliciesOutput.Policies)
+			}
+
+			if len(listPoliciesOutput.Policies) == 1 && *listPoliciesOutput.Policies[0].Name != "FullAWSAccess" {
+				t.Fatalf("Unexpected policy found on OU: %v", listPoliciesOutput.Policies)
 			}
 
 		},
-		Targets: "organization",
+		Targets: []string{"organization"},
+	},
+	{
+		Name: "Test that we can target scps only",
+		OrgYaml: `
+Organization:
+    Name: root
+    Stacks:
+      - Type: Terraform
+        Path: tf/s3-test
+    OrganizationUnits:
+      - Name: DevTenants
+      - Name: ProductionTenants
+        ServiceControlPolicies:
+          - Type: Terraform
+            Path: tf/scp-test
+    Accounts:
+      - AccountName: master
+        Email: master@example.com
+      - AccountName: test
+        Email: test@example.com
+`,
+		OrgInitialState: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					ServiceControlPolicies: []resource.Stack{
+						{
+							Type: "Terraform",
+							Path: "tf/scp-test",
+						},
+					},
+				},
+				{
+					OUName: "DevTenants",
+				},
+			},
+			BaselineStacks: []resource.Stack{
+				{
+					Type: "Terraform",
+					Path: "tf/s3-test",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+				{
+					AccountName: "test",
+					Email:       "test@example.com",
+				},
+			},
+		},
+		ExpectedResources: func(t *testing.T) {
+			sess, err := session.NewSession(&aws.Config{
+				Region:           aws.String("us-east-1"),
+				Endpoint:         aws.String("http://localhost:4566"),
+				S3ForcePathStyle: aws.Bool(true),
+			})
+			if err != nil {
+				t.Fatalf("Failed to create session: %v", err)
+			}
+
+			// Check S3 bucket
+			svc := s3.New(sess)
+			result, err := svc.ListBuckets(nil)
+			if err != nil {
+				t.Fatalf("Failed to list buckets: %v", err)
+			}
+
+			if len(result.Buckets) > 0 {
+				t.Fatalf("Buckets found in account: %v", result.Buckets)
+			}
+
+			// Check Organization Service
+			orgSvc := organizations.New(sess)
+			listRootsOutput, err := orgSvc.ListRoots(&organizations.ListRootsInput{})
+			if err != nil {
+				t.Fatalf("Failed to list roots: %v", err)
+			}
+
+			var rootId string
+			if len(listRootsOutput.Roots) > 0 {
+				rootId = *listRootsOutput.Roots[0].Id
+			} else {
+				t.Fatalf("No roots found")
+			}
+
+			listOUsOutput, err := orgSvc.ListOrganizationalUnitsForParent(&organizations.ListOrganizationalUnitsForParentInput{
+				ParentId: &rootId,
+			})
+			if err != nil {
+				t.Fatalf("Failed to list OUs for root: %v", err)
+			}
+
+			var productionTenantId string
+			for _, ou := range listOUsOutput.OrganizationalUnits {
+				if *ou.Name == "ProductionTenants" {
+					productionTenantId = *ou.Id
+					break
+				}
+			}
+
+			if productionTenantId == "" {
+				t.Fatalf("OU 'ProductionTenants' not found")
+			}
+
+			listPoliciesOutput, err := orgSvc.ListPoliciesForTarget(&organizations.ListPoliciesForTargetInput{
+				TargetId: &productionTenantId,
+				Filter:   aws.String("SERVICE_CONTROL_POLICY"),
+			})
+			if err != nil {
+				t.Fatalf("Failed to list policies for 'ProductionTenants': %v", err)
+			}
+
+			var scpFound bool
+			for _, policy := range listPoliciesOutput.Policies {
+				if *policy.Name == "restrict_regions" {
+					scpFound = true
+					break
+				}
+			}
+
+			if !scpFound {
+				t.Fatalf("SCP 'restrict_regions' is not attached to 'ProductionTenants'")
+			}
+
+		},
+		Targets: []string{"scp"},
+	},
+	{
+		Name: "Test that we can target stacks only",
+		OrgYaml: `
+Organization:
+    Name: root
+    OrganizationUnits:
+      - Name: DevTenants
+      - Name: ProductionTenants
+        ServiceControlPolicies:
+          - Type: Terraform
+            Path: tf/scp-test
+    Accounts:
+      - AccountName: master
+        Email: master@example.com
+        Stacks:
+          - Type: Terraform
+            Path: tf/s3-test
+      - AccountName: test
+        Email: test@example.com
+`,
+		FetchExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ParseExpected: &resource.OrganizationUnit{
+			OUName: "root",
+			ChildOUs: []*resource.OrganizationUnit{
+				{
+					OUName: "ProductionTenants",
+					ServiceControlPolicies: []resource.Stack{
+						{
+							Type: "Terraform",
+							Path: "tf/scp-test",
+						},
+					},
+				},
+				{
+					OUName: "DevTenants",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+					BaselineStacks: []resource.Stack{
+						{
+							Type: "Terraform",
+							Path: "tf/s3-test",
+						},
+					},
+				},
+				{
+					AccountName: "test",
+					Email:       "test@example.com",
+				},
+			},
+		},
+		ExpectedResources: func(t *testing.T) {
+			sess, err := session.NewSession(&aws.Config{
+				Region:           aws.String("us-east-1"),
+				Endpoint:         aws.String("http://localhost:4566"),
+				S3ForcePathStyle: aws.Bool(true),
+			})
+			if err != nil {
+				t.Fatalf("Failed to create session: %v", err)
+			}
+
+			// Check S3 bucket
+			svc := s3.New(sess)
+			result, err := svc.ListBuckets(nil)
+			if err != nil {
+				t.Fatalf("Failed to list buckets: %v", err)
+			}
+
+			if len(result.Buckets) == 0 {
+				t.Fatal("No buckets created")
+			}
+
+			assert.Equal(t, *result.Buckets[0].Name, "test")
+		},
+		Targets: []string{"stacks"},
 	},
 }
 
@@ -695,7 +1207,7 @@ func TestEndToEnd(t *testing.T) {
 		parsedOrg, err := ymlparser.ParseOrganizationV2(ctx, "organization.yml")
 		assert.NoError(t, err, "Failed to parse organization.yml")
 
-		compareOrganizationUnits(t, test.Expected, parsedOrg, false)
+		compareOrganizationUnits(t, test.ParseExpected, parsedOrg, false)
 
 		cmd.ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, test.Targets)
 
@@ -703,7 +1215,7 @@ func TestEndToEnd(t *testing.T) {
 		assert.NoError(t, err, "Failed to fetch rootOU")
 
 		// Ignore stacks because we do not know which stacks were deployed to the org in AWS.
-		compareOrganizationUnits(t, test.Expected, &fetchedOrg, true)
+		compareOrganizationUnits(t, test.FetchExpected, &fetchedOrg, true)
 
 		test.ExpectedResources(t)
 	}

--- a/tests/end2end_test.go
+++ b/tests/end2end_test.go
@@ -7,6 +7,10 @@ import (
 	"runtime/debug"
 	"testing"
 
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/santiago-labs/telophasecli/cmd"
 	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/lib/awsorgs"
@@ -17,21 +21,364 @@ import (
 )
 
 type E2ETestCase struct {
-	Name            string
-	OrgInitialState *resource.OrganizationUnit
-	OrgYaml         string
-	Expected        *resource.OrganizationUnit
+	Name              string
+	OrgInitialState   *resource.OrganizationUnit
+	OrgYaml           string
+	Expected          *resource.OrganizationUnit
+	Targets           string
+	ExpectedResources func(t *testing.T)
 }
 
 var tests = []E2ETestCase{
+	// 	{
+	// 		Name: "Test that we can create OUs",
+	// 		OrgYaml: `
+	// Organization:
+	//     Name: root
+	//     OrganizationUnits:
+	//       - Name: ProductionTenants
+	//       - Name: Development
+	//     Accounts:
+	//       - AccountName: master
+	//         Email: master@example.com
+	// `,
+	// 		Expected: &resource.OrganizationUnit{
+	// 			OUName: "root",
+	// 			ChildOUs: []*resource.OrganizationUnit{
+	// 				{
+	// 					OUName: "ProductionTenants",
+	// 				},
+	// 				{
+	// 					OUName: "Development",
+	// 				},
+	// 			},
+	// 			Accounts: []*resource.Account{
+	// 				{
+	// 					AccountName:       "master",
+	// 					Email:             "master@example.com",
+	// 					ManagementAccount: true,
+	// 				},
+	// 			},
+	// 		},
+	// 		ExpectedResources: func(*testing.T) {},
+	// 	},
+	// 	{
+	// 		Name: "Test that we can create nested OUs",
+	// 		OrgYaml: `
+	// Organization:
+	//     Name: root
+	//     OrganizationUnits:
+	//       - Name: ProductionTenants
+	//         OrganizationUnits:
+	//           - Name: ProductionEU
+	//           - Name: ProductionUS
+	//       - Name: Development
+	//         OrganizationUnits:
+	//           - Name: DevEU
+	//           - Name: DevUS
+	//     Accounts:
+	//       - AccountName: master
+	//         Email: master@example.com
+	// `,
+	// 		Expected: &resource.OrganizationUnit{
+	// 			OUName: "root",
+	// 			ChildOUs: []*resource.OrganizationUnit{
+	// 				{
+	// 					OUName: "ProductionTenants",
+	// 					ChildOUs: []*resource.OrganizationUnit{
+	// 						{
+	// 							OUName: "ProductionEU",
+	// 						},
+	// 						{
+	// 							OUName: "ProductionUS",
+	// 						},
+	// 					},
+	// 				},
+	// 				{
+	// 					OUName: "Development",
+	// 					ChildOUs: []*resource.OrganizationUnit{
+	// 						{
+	// 							OUName: "DevEU",
+	// 						},
+	// 						{
+	// 							OUName: "DevUS",
+	// 						},
+	// 					},
+	// 				},
+	// 			},
+	// 			Accounts: []*resource.Account{
+	// 				{
+	// 					AccountName:       "master",
+	// 					Email:             "master@example.com",
+	// 					ManagementAccount: true,
+	// 				},
+	// 			},
+	// 		},
+	// 		ExpectedResources: func(*testing.T) {},
+	// 	},
+	// 	{
+	// 		Name: "Test that we can create accounts",
+	// 		OrgYaml: `
+	// Organization:
+	//   Name: root
+	//   Accounts:
+	//     - AccountName: master
+	//       Email: master@example.com
+	//     - AccountName: test1
+	//       Email: test1@example.com
+	//     - AccountName: test2
+	//       Email: test2@example.com
+	// `,
+	// 		Expected: &resource.OrganizationUnit{
+	// 			OUName: "root",
+	// 			Accounts: []*resource.Account{
+	// 				{
+	// 					AccountName:       "master",
+	// 					Email:             "master@example.com",
+	// 					ManagementAccount: true,
+	// 				},
+	// 				{
+	// 					AccountName: "test1",
+	// 					Email:       "test1@example.com",
+	// 				},
+	// 				{
+	// 					AccountName: "test2",
+	// 					Email:       "test2@example.com",
+	// 				},
+	// 			},
+	// 		},
+	// 		ExpectedResources: func(*testing.T) {},
+	// 	},
+	// 	{
+	// 		Name: "Test that we can create accounts in OUs",
+	// 		OrgYaml: `
+	// Organization:
+	//   Name: root
+	//   OrganizationUnits:
+	//     - Name: ProductionTenants
+	//       Accounts:
+	//         - AccountName: test1
+	//           Email: test1@example.com
+	//       OrganizationUnits:
+	//         - Name: ProductionEU
+	//         - Name: ProductionUS
+	//           Accounts:
+	//             - AccountName: test2
+	//               Email: test2@example.com
+	//     - Name: Development
+	//       OrganizationUnits:
+	//         - Name: DevEU
+	//           Accounts:
+	//             - AccountName: test3
+	//               Email: test3@example.com
+	//             - AccountName: test4
+	//               Email: test4@example.com
+	//             - AccountName: test5
+	//               Email: test5@example.com
+	//         - Name: DevUS
+	//           Accounts:
+	//             - AccountName: test6
+	//               Email: test6@example.com
+	//             - AccountName: test7
+	//               Email: test7@example.com
+	//   Accounts:
+	//     - AccountName: master
+	//       Email: master@example.com
+	//     - AccountName: test8
+	//       Email: test8@example.com
+	//     - AccountName: test9
+	//       Email: test9@example.com
+	// `,
+	// 		Expected: &resource.OrganizationUnit{
+	// 			OUName: "root",
+	// 			ChildOUs: []*resource.OrganizationUnit{
+	// 				{
+	// 					OUName: "ProductionTenants",
+	// 					Accounts: []*resource.Account{
+	// 						{
+	// 							AccountName: "test1",
+	// 							Email:       "test1@example.com",
+	// 						},
+	// 					},
+	// 					ChildOUs: []*resource.OrganizationUnit{
+	// 						{
+	// 							OUName: "ProductionEU",
+	// 						},
+	// 						{
+	// 							OUName: "ProductionUS",
+	// 							Accounts: []*resource.Account{
+	// 								{
+	// 									AccountName: "test2",
+	// 									Email:       "test2@example.com",
+	// 								},
+	// 							},
+	// 						},
+	// 					},
+	// 				},
+	// 				{
+	// 					OUName: "Development",
+	// 					ChildOUs: []*resource.OrganizationUnit{
+	// 						{
+	// 							OUName: "DevEU",
+	// 							Accounts: []*resource.Account{
+	// 								{
+	// 									AccountName: "test3",
+	// 									Email:       "test3@example.com",
+	// 								},
+	// 								{
+	// 									AccountName: "test4",
+	// 									Email:       "test4@example.com",
+	// 								},
+	// 								{
+	// 									AccountName: "test5",
+	// 									Email:       "test5@example.com",
+	// 								},
+	// 							},
+	// 						},
+	// 						{
+	// 							OUName: "DevUS",
+	// 							Accounts: []*resource.Account{
+	// 								{
+	// 									AccountName: "test6",
+	// 									Email:       "test6@example.com",
+	// 								},
+	// 								{
+	// 									AccountName: "test7",
+	// 									Email:       "test7@example.com",
+	// 								},
+	// 							},
+	// 						},
+	// 					},
+	// 				},
+	// 			},
+	// 			Accounts: []*resource.Account{
+	// 				{
+	// 					AccountName:       "master",
+	// 					Email:             "master@example.com",
+	// 					ManagementAccount: true,
+	// 				},
+	// 				{
+	// 					AccountName: "test8",
+	// 					Email:       "test8@example.com",
+	// 				},
+	// 				{
+	// 					AccountName: "test9",
+	// 					Email:       "test9@example.com",
+	// 				},
+	// 			},
+	// 		},
+	// 		ExpectedResources: func(*testing.T) {},
+	// 	},
+	// 	{
+	// 		Name: "Test that we can move Accounts between OUs",
+	// 		OrgInitialState: &resource.OrganizationUnit{
+	// 			OUName: "root",
+	// 			ChildOUs: []*resource.OrganizationUnit{
+	// 				{
+	// 					OUName: "US Engineers",
+	// 					Accounts: []*resource.Account{
+	// 						{
+	// 							AccountName: "Engineer A",
+	// 							Email:       "engineerA@example.com",
+	// 						},
+	// 						{
+	// 							AccountName: "Engineer B",
+	// 							Email:       "engineerB@example.com",
+	// 						},
+	// 					},
+	// 				},
+	// 				{
+	// 					OUName: "EU Engineers",
+	// 					Accounts: []*resource.Account{
+	// 						{
+	// 							AccountName: "Engineer C",
+	// 							Email:       "engineerC@example.com",
+	// 						},
+	// 						{
+	// 							AccountName: "Engineer D",
+	// 							Email:       "engineerD@example.com",
+	// 						},
+	// 					},
+	// 				},
+	// 			},
+	// 			Accounts: []*resource.Account{
+	// 				{
+	// 					AccountName: "master",
+	// 					Email:       "master@example.com",
+	// 				},
+	// 			},
+	// 		},
+	// 		OrgYaml: `
+	// Organization:
+	//     Name: root
+	//     OrganizationUnits:
+	//       - Name: US Engineers
+	//         Accounts:
+	//           - AccountName: Engineer A
+	//             Email: engineerA@example.com
+	//       - Name: EU Engineers
+	//         Accounts:
+	//           - AccountName: Engineer C
+	//             Email: engineerC@example.com
+	//           - AccountName: Engineer D
+	//             Email: engineerD@example.com
+	//           - AccountName: Engineer B
+	//             Email: engineerB@example.com
+	//     Accounts:
+	//       - AccountName: master
+	//         Email: master@example.com
+	// `,
+	// 		Expected: &resource.OrganizationUnit{
+	// 			OUName: "root",
+	// 			ChildOUs: []*resource.OrganizationUnit{
+	// 				{
+	// 					OUName: "US Engineers",
+	// 					Accounts: []*resource.Account{
+	// 						{
+	// 							AccountName: "Engineer A",
+	// 							Email:       "engineerA@example.com",
+	// 						},
+	// 					},
+	// 				},
+	// 				{
+	// 					OUName: "EU Engineers",
+	// 					Accounts: []*resource.Account{
+	// 						{
+	// 							AccountName: "Engineer B",
+	// 							Email:       "engineerB@example.com",
+	// 						},
+	// 						{
+	// 							AccountName: "Engineer C",
+	// 							Email:       "engineerC@example.com",
+	// 						},
+	// 						{
+	// 							AccountName: "Engineer D",
+	// 							Email:       "engineerD@example.com",
+	// 						},
+	// 					},
+	// 				},
+	// 			},
+	// 			Accounts: []*resource.Account{
+	// 				{
+	// 					AccountName:       "master",
+	// 					Email:             "master@example.com",
+	// 					ManagementAccount: true,
+	// 				},
+	// 			},
+	// 		},
+	// 		ExpectedResources: func(*testing.T) {},
+	// 	},
 	{
-		Name: "Test that we can create OUs",
+		Name: "Test that we can apply SCPs",
 		OrgYaml: `
 Organization:
     Name: root
     OrganizationUnits:
       - Name: ProductionTenants
-      - Name: Development 
+        ServiceControlPolicies:
+          - Type: Terraform
+            Path: tf/scp-test
+      - Name: Development
     Accounts:
       - AccountName: master
         Email: master@example.com
@@ -41,6 +388,12 @@ Organization:
 			ChildOUs: []*resource.OrganizationUnit{
 				{
 					OUName: "ProductionTenants",
+					ServiceControlPolicies: []resource.Stack{
+						{
+							Type: "Terraform",
+							Path: "tf/scp-test",
+						},
+					},
 				},
 				{
 					OUName: "Development",
@@ -54,192 +407,158 @@ Organization:
 				},
 			},
 		},
+		ExpectedResources: func(t *testing.T) {
+			sess, err := session.NewSession(&aws.Config{
+				Region:   aws.String("us-east-1"),
+				Endpoint: aws.String("http://localhost:4566"),
+			})
+			if err != nil {
+				t.Fatalf("Failed to create session: %v", err)
+			}
+
+			orgSvc := organizations.New(sess)
+			listRootsOutput, err := orgSvc.ListRoots(&organizations.ListRootsInput{})
+			if err != nil {
+				t.Fatalf("Failed to list roots: %v", err)
+			}
+
+			var rootId string
+			if len(listRootsOutput.Roots) > 0 {
+				rootId = *listRootsOutput.Roots[0].Id
+			} else {
+				t.Fatalf("No roots found")
+			}
+
+			listOUsOutput, err := orgSvc.ListOrganizationalUnitsForParent(&organizations.ListOrganizationalUnitsForParentInput{
+				ParentId: &rootId,
+			})
+			if err != nil {
+				t.Fatalf("Failed to list OUs for root: %v", err)
+			}
+
+			var productionTenantId string
+			for _, ou := range listOUsOutput.OrganizationalUnits {
+				if *ou.Name == "ProductionTenants" {
+					productionTenantId = *ou.Id
+					break
+				}
+			}
+
+			if productionTenantId == "" {
+				t.Fatalf("OU 'ProductionTenants' not found")
+			}
+
+			listPoliciesOutput, err := orgSvc.ListPoliciesForTarget(&organizations.ListPoliciesForTargetInput{
+				TargetId: &productionTenantId,
+				Filter:   aws.String("SERVICE_CONTROL_POLICY"),
+			})
+			if err != nil {
+				t.Fatalf("Failed to list policies for 'ProductionTenants': %v", err)
+			}
+
+			var scpFound bool
+			for _, policy := range listPoliciesOutput.Policies {
+				if *policy.Name == "restrict_regions" {
+					scpFound = true
+					break
+				}
+			}
+
+			if !scpFound {
+				t.Fatalf("SCP 'restrict_regions' is not attached to 'ProductionTenants'")
+			}
+		},
 	},
 	{
-		Name: "Test that we can create nested OUs",
+		Name: "Test that we can apply stacks at root",
 		OrgYaml: `
 Organization:
     Name: root
+    Stacks:
+      - Type: Terraform
+        Path: tf/s3-test
+    Accounts:
+      - AccountName: master
+        Email: master@example.com
+`,
+		Expected: &resource.OrganizationUnit{
+			OUName: "root",
+			BaselineStacks: []resource.Stack{
+				{
+					Type: "Terraform",
+					Path: "tf/s3-test",
+				},
+			},
+			Accounts: []*resource.Account{
+				{
+					AccountName:       "master",
+					Email:             "master@example.com",
+					ManagementAccount: true,
+				},
+			},
+		},
+		ExpectedResources: func(t *testing.T) {
+			sess, err := session.NewSession(&aws.Config{
+				Region:           aws.String("us-east-1"),
+				Endpoint:         aws.String("http://localhost:4566"),
+				S3ForcePathStyle: aws.Bool(true),
+			})
+			if err != nil {
+				t.Fatalf("Failed to create session: %v", err)
+			}
+
+			svc := s3.New(sess)
+			result, err := svc.ListBuckets(nil)
+			if err != nil {
+				t.Fatalf("Failed to list buckets: %v", err)
+			}
+
+			var bucketNames []string
+			for _, b := range result.Buckets {
+				bucketNames = append(bucketNames, *b.Name)
+			}
+
+			if len(bucketNames) != 1 || bucketNames[0] != "test" {
+				t.Fatalf("Test failed, expected only 'test' bucket, found buckets: %v", bucketNames)
+			}
+		},
+	},
+	{
+		Name: "Test that we can target new accounts only",
+		OrgYaml: `
+Organization:
+    Name: root
+    Stacks:
+      - Type: Terraform
+        Path: tf/s3-test
     OrganizationUnits:
       - Name: ProductionTenants
-        OrganizationUnits:
-          - Name: ProductionEU
-          - Name: ProductionUS
-      - Name: Development 
-        OrganizationUnits:
-          - Name: DevEU
-          - Name: DevUS
+        ServiceControlPolicies:
+          - Type: Terraform
+            Path: tf/scp-test
     Accounts:
       - AccountName: master
         Email: master@example.com
+      - AccountName: test
+        Email: test@example.com
 `,
 		Expected: &resource.OrganizationUnit{
 			OUName: "root",
 			ChildOUs: []*resource.OrganizationUnit{
 				{
 					OUName: "ProductionTenants",
-					ChildOUs: []*resource.OrganizationUnit{
+					ServiceControlPolicies: []resource.Stack{
 						{
-							OUName: "ProductionEU",
-						},
-						{
-							OUName: "ProductionUS",
-						},
-					},
-				},
-				{
-					OUName: "Development",
-					ChildOUs: []*resource.OrganizationUnit{
-						{
-							OUName: "DevEU",
-						},
-						{
-							OUName: "DevUS",
+							Type: "Terraform",
+							Path: "tf/scp-test",
 						},
 					},
 				},
 			},
-			Accounts: []*resource.Account{
+			BaselineStacks: []resource.Stack{
 				{
-					AccountName:       "master",
-					Email:             "master@example.com",
-					ManagementAccount: true,
-				},
-			},
-		},
-	},
-	{
-		Name: "Test that we can create accounts",
-		OrgYaml: `
-Organization:
-  Name: root
-  Accounts:
-    - AccountName: master
-      Email: master@example.com
-    - AccountName: test1
-      Email: test1@example.com
-    - AccountName: test2
-      Email: test2@example.com
-`,
-		Expected: &resource.OrganizationUnit{
-			OUName: "root",
-			Accounts: []*resource.Account{
-				{
-					AccountName:       "master",
-					Email:             "master@example.com",
-					ManagementAccount: true,
-				},
-				{
-					AccountName: "test1",
-					Email:       "test1@example.com",
-				},
-				{
-					AccountName: "test2",
-					Email:       "test2@example.com",
-				},
-			},
-		},
-	},
-	{
-		Name: "Test that we can create accounts in OUs",
-		OrgYaml: `
-Organization:
-  Name: root
-  OrganizationUnits:
-    - Name: ProductionTenants
-      Accounts:
-        - AccountName: test1
-          Email: test1@example.com
-      OrganizationUnits:
-        - Name: ProductionEU
-        - Name: ProductionUS
-          Accounts:
-            - AccountName: test2
-              Email: test2@example.com
-    - Name: Development 
-      OrganizationUnits:
-        - Name: DevEU
-          Accounts:
-            - AccountName: test3
-              Email: test3@example.com
-            - AccountName: test4
-              Email: test4@example.com
-            - AccountName: test5
-              Email: test5@example.com
-        - Name: DevUS
-          Accounts:
-            - AccountName: test6
-              Email: test6@example.com
-            - AccountName: test7
-              Email: test7@example.com
-  Accounts:
-    - AccountName: master
-      Email: master@example.com
-    - AccountName: test8
-      Email: test8@example.com
-    - AccountName: test9
-      Email: test9@example.com
-`,
-		Expected: &resource.OrganizationUnit{
-			OUName: "root",
-			ChildOUs: []*resource.OrganizationUnit{
-				{
-					OUName: "ProductionTenants",
-					Accounts: []*resource.Account{
-						{
-							AccountName: "test1",
-							Email:       "test1@example.com",
-						},
-					},
-					ChildOUs: []*resource.OrganizationUnit{
-						{
-							OUName: "ProductionEU",
-						},
-						{
-							OUName: "ProductionUS",
-							Accounts: []*resource.Account{
-								{
-									AccountName: "test2",
-									Email:       "test2@example.com",
-								},
-							},
-						},
-					},
-				},
-				{
-					OUName: "Development",
-					ChildOUs: []*resource.OrganizationUnit{
-						{
-							OUName: "DevEU",
-							Accounts: []*resource.Account{
-								{
-									AccountName: "test3",
-									Email:       "test3@example.com",
-								},
-								{
-									AccountName: "test4",
-									Email:       "test4@example.com",
-								},
-								{
-									AccountName: "test5",
-									Email:       "test5@example.com",
-								},
-							},
-						},
-						{
-							OUName: "DevUS",
-							Accounts: []*resource.Account{
-								{
-									AccountName: "test6",
-									Email:       "test6@example.com",
-								},
-								{
-									AccountName: "test7",
-									Email:       "test7@example.com",
-								},
-							},
-						},
-					},
+					Type: "Terraform",
+					Path: "tf/s3-test",
 				},
 			},
 			Accounts: []*resource.Account{
@@ -249,113 +568,79 @@ Organization:
 					ManagementAccount: true,
 				},
 				{
-					AccountName: "test8",
-					Email:       "test8@example.com",
-				},
-				{
-					AccountName: "test9",
-					Email:       "test9@example.com",
+					AccountName: "test",
+					Email:       "test@example.com",
 				},
 			},
 		},
-	},
-	{
-		Name: "Test that we can move Accounts between OUs",
-		OrgInitialState: &resource.OrganizationUnit{
-			OUName: "root",
-			ChildOUs: []*resource.OrganizationUnit{
-				{
-					OUName: "US Engineers",
-					Accounts: []*resource.Account{
-						{
-							AccountName: "Engineer A",
-							Email:       "engineerA@example.com",
-						},
-						{
-							AccountName: "Engineer B",
-							Email:       "engineerB@example.com",
-						},
-					},
-				},
-				{
-					OUName: "EU Engineers",
-					Accounts: []*resource.Account{
-						{
-							AccountName: "Engineer C",
-							Email:       "engineerC@example.com",
-						},
-						{
-							AccountName: "Engineer D",
-							Email:       "engineerD@example.com",
-						},
-					},
-				},
-			},
-			Accounts: []*resource.Account{
-				{
-					AccountName: "master",
-					Email:       "master@example.com",
-				},
-			},
+		ExpectedResources: func(t *testing.T) {
+			sess, err := session.NewSession(&aws.Config{
+				Region:           aws.String("us-east-1"),
+				Endpoint:         aws.String("http://localhost:4566"),
+				S3ForcePathStyle: aws.Bool(true),
+			})
+			if err != nil {
+				t.Fatalf("Failed to create session: %v", err)
+			}
+
+			// Check S3 bucket
+			svc := s3.New(sess)
+			result, err := svc.ListBuckets(nil)
+			if err != nil {
+				t.Fatalf("Failed to list buckets: %v", err)
+			}
+
+			if len(result.Buckets) > 0 {
+				t.Fatalf("Buckets found in account: %v", result.Buckets)
+			}
+
+			// Check Organization Service
+			orgSvc := organizations.New(sess)
+			listRootsOutput, err := orgSvc.ListRoots(&organizations.ListRootsInput{})
+			if err != nil {
+				t.Fatalf("Failed to list roots: %v", err)
+			}
+
+			var rootId string
+			if len(listRootsOutput.Roots) > 0 {
+				rootId = *listRootsOutput.Roots[0].Id
+			} else {
+				t.Fatalf("No roots found")
+			}
+
+			listOUsOutput, err := orgSvc.ListOrganizationalUnitsForParent(&organizations.ListOrganizationalUnitsForParentInput{
+				ParentId: &rootId,
+			})
+			if err != nil {
+				t.Fatalf("Failed to list OUs for root: %v", err)
+			}
+
+			var productionTenantId string
+			for _, ou := range listOUsOutput.OrganizationalUnits {
+				if *ou.Name == "ProductionTenants" {
+					productionTenantId = *ou.Id
+					break
+				}
+			}
+
+			if productionTenantId == "" {
+				t.Fatalf("OU 'ProductionTenants' not found")
+			}
+
+			listPoliciesOutput, err := orgSvc.ListPoliciesForTarget(&organizations.ListPoliciesForTargetInput{
+				TargetId: &productionTenantId,
+				Filter:   aws.String("SERVICE_CONTROL_POLICY"),
+			})
+			if err != nil {
+				t.Fatalf("Failed to list policies for 'ProductionTenants': %v", err)
+			}
+
+			if len(listPoliciesOutput.Policies) > 0 {
+				t.Fatalf("Policies found on OU: %v", listPoliciesOutput.Policies)
+			}
+
 		},
-		OrgYaml: `
-Organization:
-    Name: root
-    OrganizationUnits:
-      - Name: US Engineers
-        Accounts:
-          - AccountName: Engineer A
-            Email: engineerA@example.com
-      - Name: EU Engineers 
-        Accounts:
-          - AccountName: Engineer C
-            Email: engineerC@example.com
-          - AccountName: Engineer D
-            Email: engineerD@example.com
-          - AccountName: Engineer B
-            Email: engineerB@example.com
-    Accounts:
-      - AccountName: master
-        Email: master@example.com
-`,
-		Expected: &resource.OrganizationUnit{
-			OUName: "root",
-			ChildOUs: []*resource.OrganizationUnit{
-				{
-					OUName: "US Engineers",
-					Accounts: []*resource.Account{
-						{
-							AccountName: "Engineer A",
-							Email:       "engineerA@example.com",
-						},
-					},
-				},
-				{
-					OUName: "EU Engineers",
-					Accounts: []*resource.Account{
-						{
-							AccountName: "Engineer B",
-							Email:       "engineerB@example.com",
-						},
-						{
-							AccountName: "Engineer C",
-							Email:       "engineerC@example.com",
-						},
-						{
-							AccountName: "Engineer D",
-							Email:       "engineerD@example.com",
-						},
-					},
-				},
-			},
-			Accounts: []*resource.Account{
-				{
-					AccountName:       "master",
-					Email:             "master@example.com",
-					ManagementAccount: true,
-				},
-			},
-		},
+		Targets: "organization",
 	},
 }
 
@@ -397,10 +682,11 @@ func TestEndToEnd(t *testing.T) {
 				}
 			}
 
+			// Ignore stacks because we do not know which stacks were deployed to the org in AWS.
 			fetchedOrg, err := orgClient.FetchOUAndDescendents(ctx, rootId, mgmtAcct.AccountID)
 			assert.NoError(t, err, "Failed to fetch rootOU")
 
-			compareOrganizationUnits(t, test.OrgInitialState, &fetchedOrg)
+			compareOrganizationUnits(t, test.OrgInitialState, &fetchedOrg, true)
 		}
 
 		err = ioutil.WriteFile("organization.yml", []byte(test.OrgYaml), 0644)
@@ -409,13 +695,16 @@ func TestEndToEnd(t *testing.T) {
 		parsedOrg, err := ymlparser.ParseOrganizationV2(ctx, "organization.yml")
 		assert.NoError(t, err, "Failed to parse organization.yml")
 
-		compareOrganizationUnits(t, test.Expected, parsedOrg)
+		compareOrganizationUnits(t, test.Expected, parsedOrg, false)
 
-		cmd.ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy)
+		cmd.ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, test.Targets)
 
 		fetchedOrg, err := orgClient.FetchOUAndDescendents(ctx, rootId, mgmtAcct.AccountID)
 		assert.NoError(t, err, "Failed to fetch rootOU")
 
-		compareOrganizationUnits(t, test.Expected, &fetchedOrg)
+		// Ignore stacks because we do not know which stacks were deployed to the org in AWS.
+		compareOrganizationUnits(t, test.Expected, &fetchedOrg, true)
+
+		test.ExpectedResources(t)
 	}
 }

--- a/tests/main_test.go
+++ b/tests/main_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 	os.Exit(code)
 }
 
-func compareOrganizationUnits(t *testing.T, expected, actual *resource.OrganizationUnit) {
+func compareOrganizationUnits(t *testing.T, expected, actual *resource.OrganizationUnit, ignoreStacks bool) {
 	assert.Equal(t, expected.OUName, actual.OUName, "OU Name not equal")
 
 	sort.Slice(expected.ChildOUs, func(i, j int) bool {
@@ -82,27 +82,33 @@ func compareOrganizationUnits(t *testing.T, expected, actual *resource.Organizat
 
 	acctDiff := cmp.Diff(expected.Accounts, actual.Accounts)
 	assert.Equal(t, len(expected.Accounts), len(actual.Accounts), "Accounts not equal: %v", acctDiff)
-	assert.Equal(t, expected.BaselineStacks, actual.BaselineStacks)
-	assert.Equal(t, expected.ServiceControlPolicies, actual.ServiceControlPolicies)
+
+	if !ignoreStacks {
+		assert.Equal(t, expected.BaselineStacks, actual.BaselineStacks)
+		assert.Equal(t, expected.ServiceControlPolicies, actual.ServiceControlPolicies)
+	}
 
 	for i, childOU := range expected.ChildOUs {
-		compareOrganizationUnits(t, childOU, actual.ChildOUs[i])
+		compareOrganizationUnits(t, childOU, actual.ChildOUs[i], ignoreStacks)
 	}
 
 	for i, account := range expected.Accounts {
-		compareAccounts(t, account, actual.Accounts[i])
+		compareAccounts(t, account, actual.Accounts[i], ignoreStacks)
 	}
 }
 
-func compareAccounts(t *testing.T, expected, actual *resource.Account) {
+func compareAccounts(t *testing.T, expected, actual *resource.Account, ignoreStacks bool) {
 	assert.Equal(t, expected.Email, actual.Email, "Account Emails not equal")
 	assert.Equal(t, expected.AccountName, actual.AccountName, "Account Name not equal")
 	assert.Equal(t, expected.State, actual.State, "Account State not equal")
 	assert.Equal(t, expected.AssumeRoleName, actual.AssumeRoleName, "Account AssumeRoleName not equal")
 	assert.Equal(t, expected.ManagementAccount, actual.ManagementAccount, "Account ManagementAccount not equal")
 	assert.Equal(t, expected.Tags, actual.Tags, "Account Tags not equal")
-	assert.Equal(t, expected.BaselineStacks, actual.BaselineStacks, "Account BaselineStacks not equal")
-	assert.Equal(t, expected.ServiceControlPolicies, actual.ServiceControlPolicies, "Account ServiceControlPolicies not equal")
+
+	if !ignoreStacks {
+		assert.Equal(t, expected.BaselineStacks, actual.BaselineStacks, "Account BaselineStacks not equal")
+		assert.Equal(t, expected.ServiceControlPolicies, actual.ServiceControlPolicies, "Account ServiceControlPolicies not equal")
+	}
 }
 
 func runCmd(cmd *exec.Cmd) (string, string, error) {

--- a/tests/tf/s3-test/main.tf
+++ b/tests/tf/s3-test/main.tf
@@ -1,0 +1,7 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_s3_bucket" "test" {
+  bucket = "test"
+}

--- a/tests/tf/scp-test/main.tf
+++ b/tests/tf/scp-test/main.tf
@@ -1,0 +1,32 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+data "aws_iam_policy_document" "restrict_regions" {
+  statement {
+    sid       = "RegionRestriction"
+    effect    = "Deny"
+    actions   = ["*"]
+    resources = ["*"]
+
+    condition {
+      test     = "StringNotEquals"
+      variable = "aws:RequestedRegion"
+
+      values = [
+        "us-east-1"
+      ]
+    }
+  }
+}
+
+resource "aws_organizations_policy" "restrict_regions" {
+  name        = "restrict_regions"
+  description = "Deny all regions except US East 1."
+  content     = data.aws_iam_policy_document.restrict_regions.json
+}
+
+resource "aws_organizations_policy_attachment" "restrict_regions" {
+  policy_id = aws_organizations_policy.restrict_regions.id
+  target_id = telophase.organization_unit_id
+}


### PR DESCRIPTION
Before this pr, all resources (ie Organization, SCP, and Stacks) were all included with `telophasecli deploy` and `telophasecli diff`. This change introduces a `--targets` flag that allows you to filter the resource:
`telophasecli --targets=scp` to deploy SCPs
`telophasecli --targets=organization` to deploy Organization
`telophasecli --target=stacks` to deploy Stacks

You can specify multiple targets:
`telophasecli --targets=organization,scp` to deploy SCPs and Organization
etc