### PR TITLE
resource: allow user to specify a terraform workspace

### DIFF
--- a/examples/localstack/organization.yml
+++ b/examples/localstack/organization.yml
@@ -10,6 +10,10 @@ Organization:
           - Type: "Terraform"
             Path: "./tf/ci_iam"
             Name: "Default IAM Roles for CI"
+          - Type: "Terraform"
+            Path: "./tf/workspace"
+            Region: "eu-west-1"
+            Workspace: "${telophase.account_id}_${telophase.region}"
         Tags:
           - "production"
         Accounts:

--- a/examples/localstack/setup.sh
+++ b/examples/localstack/setup.sh
@@ -46,4 +46,6 @@ aws dynamodb create-table --table-name tf-test-state \
 --provisioned-throughput ReadCapacityUnits=5,WriteCapacityUnits=5 \
 --endpoint-url http://localhost:4566
 
+awslocal organizations create-organization --feature-set ALL
+
 print_green "Setup complete! You can now run telophasecli :)"

--- a/examples/localstack/tf/workspace/main.tf
+++ b/examples/localstack/tf/workspace/main.tf
@@ -18,7 +18,7 @@ locals {
 
 provider "aws" {
     # Two options can use ${telophase.region} or look at local config
-    region = local.region
+    region = "${telophase.region}" 
 }
 
 terraform {

--- a/examples/localstack/tf/workspace/main.tf
+++ b/examples/localstack/tf/workspace/main.tf
@@ -1,0 +1,30 @@
+resource "aws_dynamodb_table" "example" {
+  name             = "${terraform.workspace}-eu"
+
+  hash_key         = "TestTableHashKey"
+  billing_mode     = "PAY_PER_REQUEST"
+  stream_enabled   = true
+  stream_view_type = "NEW_AND_OLD_IMAGES"
+
+  attribute {
+    name = "TestTableHashKey"
+    type = "S"
+  }
+}
+
+locals {
+  region = split("_",terraform.workspace)[1]
+}
+
+provider "aws" {
+    # Two options can use ${telophase.region} or look at local config
+    region = local.region
+}
+
+terraform {
+  backend "s3" {
+    bucket = "tfstate-${telophase.account_id}"
+    key    = "workspace/terraform.tfstate"
+    region = "us-west-2"
+  }
+}

--- a/lib/awssts/awssts.go
+++ b/lib/awssts/awssts.go
@@ -9,12 +9,17 @@ import (
 func SetEnviron(currEnv []string,
 	accessKeyID,
 	secretAccessKey,
-	sessionToken string) []string {
+	sessionToken string,
+	awsRegion *string) []string {
 	var newEnv []string
 	for _, e := range currEnv {
 		if strings.Contains(e, "AWS_ACCESS_KEY_ID=") ||
 			strings.Contains(e, "AWS_SECRET_ACCESS_KEY=") ||
 			strings.Contains(e, "AWS_SESSION_TOKEN=") {
+			continue
+		}
+
+		if awsRegion != nil && strings.Contains(e, "AWS_REGION=") {
 			continue
 		}
 
@@ -25,7 +30,11 @@ func SetEnviron(currEnv []string,
 		"AWS_ACCESS_KEY_ID="+accessKeyID,
 		"AWS_SECRET_ACCESS_KEY="+secretAccessKey,
 		"AWS_SESSION_TOKEN="+sessionToken,
-		"AWS_REGION="+"us-west-2")
+	)
+
+	if awsRegion != nil {
+		newEnv = append(newEnv, *awsRegion)
+	}
 
 	if localstack.UsingLocalStack() {
 		// We need to set this to true for localstack so that tflocal will use

--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -104,6 +104,7 @@ Stacks:
     Type:  # (Required) "CDK" or "Terraform".
     Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
     RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
+    Region: # (Optional) What region the stack's resources will be provisioned in.
 ```
 
 ### Example

--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -105,6 +105,7 @@ Stacks:
     Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
     RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
     Region: # (Optional) What region the stack's resources will be provisioned in.
+    Workspace: # (Optional) Specify a Terraform workspace to use.
 ```
 
 ### Example

--- a/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
+++ b/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
@@ -47,4 +47,5 @@ Stacks:
     Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
     RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
     Region: # (Optional) What region the stack's resources will be provisioned in.
+    Workspace: # (Optional) Specify a Terraform workspace to use. 
 ```

--- a/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
+++ b/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
@@ -22,6 +22,8 @@ Organization:
                 # This stack will be applied to `Safety Firmware` account only.
               - Path: tf/safety/firmware_bucket 
                 Type: Terraform
+                # You can set the region for where you want the resources to be created.
+                Region: "us-west-2"
           - Email: safety+ingestion@example.app
             AccountName: Safety Ingestion Team
       - Name: Development
@@ -33,4 +35,16 @@ Organization:
         Accounts:
           - Email: eng1@example.app
             AccountName: Engineer A
+```
+
+# Stacks
+CDK and Terraform stacks can be assigned to `Account`s and `OrganizationUnits`s. Stacks assigned to `OrganizationUnits` will be applied to all child `Account`s.
+
+```yaml
+Stacks:
+  - Path:  # (Required) Path to CDK or Terraform project. This must be a directory.
+    Type:  # (Required) "CDK" or "Terraform".
+    Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
+    RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
+    Region: # (Optional) What region the stack's resources will be provisioned in.
 ```

--- a/resource/stack.go
+++ b/resource/stack.go
@@ -4,5 +4,14 @@ type Stack struct {
 	Name            string `yaml:"Name"`
 	Type            string `yaml:"Type"`
 	Path            string `yaml:"Path"`
+	Region          string `yaml:"Region,omitempty"`
 	RoleOverrideARN string `yaml:"RoleOverrideARN,omitempty"`
+}
+
+func (s Stack) AWSRegionEnv() *string {
+	if s.Region != "" {
+		v := "AWS_REGION=" + s.Region
+		return &v
+	}
+	return nil
 }

--- a/resource/stack.go
+++ b/resource/stack.go
@@ -6,6 +6,7 @@ type Stack struct {
 	Path            string `yaml:"Path"`
 	Region          string `yaml:"Region,omitempty"`
 	RoleOverrideARN string `yaml:"RoleOverrideARN,omitempty"`
+	Workspace       string `yaml:"Workspace,omitempty"`
 }
 
 func (s Stack) AWSRegionEnv() *string {
@@ -14,4 +15,8 @@ func (s Stack) AWSRegionEnv() *string {
 		return &v
 	}
 	return nil
+}
+
+func (s Stack) WorkspaceEnabled() bool {
+	return s.Workspace != ""
 }

--- a/resourceoperation/cdk.go
+++ b/resourceoperation/cdk.go
@@ -104,7 +104,9 @@ func (co *cdkOperation) Call(ctx context.Context) error {
 		cmd.Env = awssts.SetEnviron(os.Environ(),
 			*opRole.Credentials.AccessKeyId,
 			*opRole.Credentials.SecretAccessKey,
-			*opRole.Credentials.SessionToken)
+			*opRole.Credentials.SessionToken,
+			co.Stack.AWSRegionEnv(),
+		)
 	}
 	if err := co.OutputUI.RunCmd(cmd, *co.Account); err != nil {
 		return err
@@ -138,7 +140,9 @@ func bootstrapCDK(result *sts.AssumeRoleOutput, region string, acct resource.Acc
 		cmd.Env = awssts.SetEnviron(os.Environ(),
 			*result.Credentials.AccessKeyId,
 			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken)
+			*result.Credentials.SessionToken,
+			stack.AWSRegionEnv(),
+		)
 	}
 
 	return cmd
@@ -162,7 +166,9 @@ func synthCDK(result *sts.AssumeRoleOutput, acct resource.Account, stack resourc
 		cmd.Env = awssts.SetEnviron(os.Environ(),
 			*result.Credentials.AccessKeyId,
 			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken)
+			*result.Credentials.SessionToken,
+			stack.AWSRegionEnv(),
+		)
 	}
 
 	return cmd

--- a/resourceoperation/scp.go
+++ b/resourceoperation/scp.go
@@ -125,7 +125,10 @@ func (so *scpOperation) Call(ctx context.Context) error {
 			initTFCmd.Env = awssts.SetEnviron(os.Environ(),
 				*acctRole.Credentials.AccessKeyId,
 				*acctRole.Credentials.SecretAccessKey,
-				*acctRole.Credentials.SessionToken)
+				*acctRole.Credentials.SessionToken,
+				// SCPs can't have regions
+				nil,
+			)
 		}
 		if err := so.OutputUI.RunCmd(initTFCmd, *so.MgmtAcct); err != nil {
 			return err
@@ -151,7 +154,10 @@ func (so *scpOperation) Call(ctx context.Context) error {
 		cmd.Env = awssts.SetEnviron(os.Environ(),
 			*acctRole.Credentials.AccessKeyId,
 			*acctRole.Credentials.SecretAccessKey,
-			*acctRole.Credentials.SessionToken)
+			*acctRole.Credentials.SessionToken,
+			// SCPs don't have regions
+			nil,
+		)
 	}
 
 	if err := so.OutputUI.RunCmd(cmd, *so.MgmtAcct); err != nil {

--- a/resourceoperation/scp.go
+++ b/resourceoperation/scp.go
@@ -190,7 +190,7 @@ func (so *scpOperation) initTf() (*exec.Cmd, error) {
 			return nil, fmt.Errorf("failed to create directory %s: %v", terraformDir, err)
 		}
 
-		if err := terraform.CopyDir(so.Stack.Path, workingPath, so.targetResource()); err != nil {
+		if err := terraform.CopyDir(so.Stack, workingPath, so.targetResource()); err != nil {
 			return nil, fmt.Errorf("failed to copy files from %s to %s: %v", so.Stack.Path, workingPath, err)
 		}
 

--- a/resourceoperation/terraform.go
+++ b/resourceoperation/terraform.go
@@ -131,7 +131,7 @@ func (to *tfOperation) initTf(role *sts.AssumeRoleOutput) *exec.Cmd {
 			return nil
 		}
 
-		if err := terraform.CopyDir(to.Stack.Path, workingPath, *to.Account); err != nil {
+		if err := terraform.CopyDir(to.Stack, workingPath, *to.Account); err != nil {
 			to.OutputUI.Print(fmt.Sprintf("Error: failed to copy files from %s to %s: %v", to.Stack.Path, workingPath, err), *to.Account)
 			return nil
 		}

--- a/resourceoperation/terraform.go
+++ b/resourceoperation/terraform.go
@@ -83,7 +83,9 @@ func (to *tfOperation) Call(ctx context.Context) error {
 	cmd.Env = awssts.SetEnviron(os.Environ(),
 		*stackRole.Credentials.AccessKeyId,
 		*stackRole.Credentials.SecretAccessKey,
-		*stackRole.Credentials.SessionToken)
+		*stackRole.Credentials.SessionToken,
+		to.Stack.AWSRegionEnv(),
+	)
 
 	if err := to.OutputUI.RunCmd(cmd, *to.Account); err != nil {
 		return err
@@ -128,7 +130,9 @@ func (to *tfOperation) initTf(role *sts.AssumeRoleOutput) *exec.Cmd {
 		cmd.Env = awssts.SetEnviron(os.Environ(),
 			*role.Credentials.AccessKeyId,
 			*role.Credentials.SecretAccessKey,
-			*role.Credentials.SessionToken)
+			*role.Credentials.SessionToken,
+			to.Stack.AWSRegionEnv(),
+		)
 
 		return cmd
 	}


### PR DESCRIPTION
This allows a user to specify the Terraform workspace and it can be
interpolated with ${telophase.account_id} or ${telophase.region} into
the workspace name.
