### PR TITLE
Handle Empty Targets 

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -38,12 +38,13 @@ var deployCmd = &cobra.Command{
 			return
 		}
 		var consoleUI runner.ConsoleUI
+		parsedTargets := filterEmptyStrings(strings.Split(targets, ","))
 		if useTUI {
 			consoleUI = runner.NewTUI()
-			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, strings.Split(targets, ","))
+			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, parsedTargets)
 		} else {
 			consoleUI = runner.NewSTDOut()
-			ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, strings.Split(targets, ","))
+			ProcessOrgEndToEnd(consoleUI, resourceoperation.Deploy, parsedTargets)
 		}
 
 		consoleUI.Start()

--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -29,12 +29,14 @@ var diffCmd = &cobra.Command{
 			return
 		}
 		var consoleUI runner.ConsoleUI
+		parsedTargets := filterEmptyStrings(strings.Split(targets, ","))
+
 		if useTUI {
 			consoleUI = runner.NewTUI()
-			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, strings.Split(targets, ","))
+			go ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, parsedTargets)
 		} else {
 			consoleUI = runner.NewSTDOut()
-			ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, strings.Split(targets, ","))
+			ProcessOrgEndToEnd(consoleUI, resourceoperation.Diff, parsedTargets)
 		}
 
 		consoleUI.Start()

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -166,3 +166,13 @@ func resolveMgmtAcct(
 	}
 	return fetchedMgmtAcct, nil
 }
+
+func filterEmptyStrings(slice []string) []string {
+	var result []string
+	for _, str := range slice {
+		if str != "" {
+			result = append(result, str)
+		}
+	}
+	return result
+}

--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -271,7 +271,6 @@ func (c Client) CreateAccount(
 	}
 
 	for {
-		time.Sleep(15 * time.Second)
 
 		requestId := *out.CreateAccountStatus.Id
 		currStatus, err := c.organizationClient.DescribeCreateAccountStatus(&organizations.DescribeCreateAccountStatusInput{
@@ -298,6 +297,8 @@ func (c Client) CreateAccount(
 		default:
 			return "", fmt.Errorf("unexpected state: %s", state)
 		}
+
+		time.Sleep(15 * time.Second)
 	}
 }
 


### PR DESCRIPTION
`strings.Split("", ",")` returns an array with a single item, `""`. This caused the logic gated by `if len(targets) == 0` to be skipped