### PR TITLE
Allow region to be "all" or a comma separated list

### DIFF
--- a/cmd/iac.go
+++ b/cmd/iac.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/samsarahq/go/oops"
 	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/resource"
 	"github.com/santiago-labs/telophasecli/resourceoperation"
@@ -27,7 +28,10 @@ func runIAC(
 				return
 			}
 
-			ops := resourceoperation.CollectAccountOps(ctx, consoleUI, cmd, &acct, stacks)
+			ops, err := resourceoperation.CollectAccountOps(ctx, consoleUI, cmd, &acct, stacks)
+			if err != nil {
+				panic(oops.Wrapf(err, "error collecting account ops for acct: %s", acct.AccountID))
+			}
 
 			if len(ops) == 0 {
 				consoleUI.Print("No stacks to deploy\n", acct)

--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -104,7 +104,7 @@ Stacks:
     Type:  # (Required) "CDK" or "Terraform".
     Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
     RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
-    Region: # (Optional) What region the stack's resources will be provisioned in.
+    Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use.
 ```
 

--- a/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
+++ b/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
@@ -46,6 +46,6 @@ Stacks:
     Type:  # (Required) "CDK" or "Terraform".
     Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
     RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
-    Region: # (Optional) What region the stack's resources will be provisioned in.
+    Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use. 
 ```

--- a/resource/account.go
+++ b/resource/account.go
@@ -80,15 +80,27 @@ func (a Account) AllBaselineStacks() ([]Stack, error) {
 	// account.
 	var returnStacks []Stack
 	for i := range stacks {
-		if stacks[i].Region == "all" {
-			generatedStacks, err := a.GenerateStacks(stacks[i])
+		currStack := stacks[i]
+
+		if currStack.Region == "all" {
+			generatedStacks, err := a.GenerateStacks(currStack)
 			if err != nil {
 				return nil, err
 			}
 			returnStacks = append(returnStacks, generatedStacks...)
 			continue
 		}
-		returnStacks = append(returnStacks, stacks[i])
+
+		// Regions can be comma separated to target just a few
+		splitRegionStack := strings.Split(currStack.Region, ",")
+		if len(splitRegionStack) > 1 {
+			for _, region := range splitRegionStack {
+				returnStacks = append(returnStacks, currStack.NewForRegion(region))
+			}
+			continue
+		}
+
+		returnStacks = append(returnStacks, currStack)
 	}
 
 	return returnStacks, nil

--- a/resource/stack.go
+++ b/resource/stack.go
@@ -1,5 +1,9 @@
 package resource
 
+import (
+	"github.com/samsarahq/go/oops"
+)
+
 type Stack struct {
 	Name            string `yaml:"Name"`
 	Type            string `yaml:"Type"`
@@ -7,6 +11,17 @@ type Stack struct {
 	Region          string `yaml:"Region,omitempty"`
 	RoleOverrideARN string `yaml:"RoleOverrideARN,omitempty"`
 	Workspace       string `yaml:"Workspace,omitempty"`
+}
+
+func (s Stack) NewForRegion(region string) Stack {
+	return Stack{
+		Name:            s.Name,
+		Type:            s.Type,
+		Path:            s.Path,
+		Region:          region,
+		RoleOverrideARN: s.RoleOverrideARN,
+		Workspace:       s.Workspace,
+	}
 }
 
 func (s Stack) AWSRegionEnv() *string {
@@ -19,4 +34,23 @@ func (s Stack) AWSRegionEnv() *string {
 
 func (s Stack) WorkspaceEnabled() bool {
 	return s.Workspace != ""
+}
+
+func (s Stack) Validate() error {
+	switch os := s.Type; os {
+	case "Terraform":
+		return nil
+
+	case "CDK":
+		if s.Workspace != "" {
+			return oops.Errorf("Workspace: (%s) should not be set for CDK stack", s.Workspace)
+		}
+		return nil
+
+	case "":
+		return oops.Errorf("stack type needs to be set for stack: %+v", s)
+
+	default:
+		return oops.Errorf("only support stack types of `Terraform` and `CDK` not: %s", s.Type)
+	}
 }

--- a/resourceoperation/account.go
+++ b/resourceoperation/account.go
@@ -50,13 +50,21 @@ func CollectAccountOps(
 	operation int,
 	acct *resource.Account,
 	stackFilter string,
-) []ResourceOperation {
+) ([]ResourceOperation, error) {
 
 	var acctStacks []resource.Stack
 	if stackFilter != "" && stackFilter != "*" {
-		acctStacks = append(acctStacks, acct.FilterBaselineStacks(stackFilter)...)
+		baselineStacks, err := acct.FilterBaselineStacks(stackFilter)
+		if err != nil {
+			return nil, err
+		}
+		acctStacks = append(acctStacks, baselineStacks...)
 	} else {
-		acctStacks = append(acctStacks, acct.AllBaselineStacks()...)
+		baselineStacks, err := acct.AllBaselineStacks()
+		if err != nil {
+			return nil, err
+		}
+		acctStacks = append(acctStacks, baselineStacks...)
 	}
 
 	var ops []ResourceOperation
@@ -68,7 +76,7 @@ func CollectAccountOps(
 		}
 	}
 
-	return ops
+	return ops, nil
 }
 
 func (ao *accountOperation) AddDependent(op ResourceOperation) {


### PR DESCRIPTION
The region can now be set to:
-  `"all"` will deploy to all enabled regions within the specific account. 
- comma-separated list of regions to deploy to. For example: `"us-west-2,eu-west-1"`

Also bubble up some errors to the top level in this PR