### PR TITLE
Allow Stack targeting with workspaces

### DIFF
--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -11,6 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/organizations"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/samsarahq/go/oops"
 	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/lib/awssess"
 	"github.com/santiago-labs/telophasecli/resource"
@@ -318,7 +319,7 @@ func (c Client) CloseAccounts(ctx context.Context, accts []*organizations.Accoun
 func (c Client) GetRootId() (string, error) {
 	rootsOutput, err := c.organizationClient.ListRoots(&organizations.ListRootsInput{})
 	if err != nil {
-		return "", err
+		return "", oops.Wrapf(err, "organizaqtions.ListRootsInput, make sure you have access to organizations from this role")
 	}
 	if len(rootsOutput.Roots) > 0 {
 		return *rootsOutput.Roots[0].Id, nil
@@ -346,7 +347,7 @@ func (c Client) ListAccountsForParent(parentID string) ([]*organizations.Account
 		return !lastPage
 	})
 
-	return accounts, err
+	return accounts, oops.Wrapf(err, "organizations.ListAccountsForParent")
 }
 
 func (c Client) FetchOUAndDescendents(ctx context.Context, ouID, mgmtAccountID string) (resource.OrganizationUnit, error) {

--- a/lib/terraform/local.go
+++ b/lib/terraform/local.go
@@ -52,6 +52,11 @@ func CopyDir(stack resource.Stack, dst string, resource resource.Resource) error
 }
 
 func replaceVariablesInFile(srcFile, dstFile string, resource resource.Resource, stack resource.Stack) error {
+	fileInfo, err := os.Stat(srcFile)
+	if err != nil {
+		return oops.Wrapf(err, "error accessing file %s", srcFile)
+	}
+
 	content, err := ioutil.ReadFile(srcFile)
 	if err != nil {
 		return err
@@ -76,5 +81,5 @@ func replaceVariablesInFile(srcFile, dstFile string, resource resource.Resource,
 		return oops.Errorf("Region needs to be set on stack if performing substitution")
 	}
 
-	return ioutil.WriteFile(dstFile, []byte(updatedContent), 0644)
+	return ioutil.WriteFile(dstFile, []byte(updatedContent), fileInfo.Mode())
 }

--- a/lib/ymlparser/organizationv2.go
+++ b/lib/ymlparser/organizationv2.go
@@ -101,7 +101,7 @@ func hydrateOUID(orgClient awsorgs.Client, parsedOU *resource.OrganizationUnit, 
 		parsedOU.OUID = providerOU.Id
 		providerChildren, err := orgClient.GetOrganizationUnitChildren(context.TODO(), *parsedOU.OUID)
 		if err != nil {
-			return err
+			return oops.Wrapf(err, "GetOrganizationUnitChildren for OUID: %s", *parsedOU.OUID)
 		}
 
 		for _, parsedChild := range parsedOU.ChildOUs {

--- a/resource/account.go
+++ b/resource/account.go
@@ -148,23 +148,15 @@ func (a Account) FilterBaselineStacks(stackNames string) ([]Stack, error) {
 		return nil, err
 	}
 
-	for _, stack := range baselineStacks {
+	for i, stack := range baselineStacks {
 		acctStackNames := strings.Split(stack.Name, ",")
-		var matchingStackNames []string
 		for _, name := range acctStackNames {
 			for _, targetName := range targetStackNames {
 				if strings.TrimSpace(name) == strings.TrimSpace(targetName) {
-					matchingStackNames = append(matchingStackNames, name)
+					matchingStacks = append(matchingStacks, baselineStacks[i])
 					break
 				}
 			}
-		}
-		if len(matchingStackNames) > 0 {
-			matchingStacks = append(matchingStacks, Stack{
-				Path: stack.Path,
-				Type: stack.Type,
-				Name: strings.Join(matchingStackNames, ","),
-			})
 		}
 	}
 	return matchingStacks, nil
@@ -173,24 +165,17 @@ func (a Account) FilterBaselineStacks(stackNames string) ([]Stack, error) {
 func (a Account) FilterServiceControlPolicies(stackNames string) []Stack {
 	var matchingStacks []Stack
 	targetStackNames := strings.Split(stackNames, ",")
-	for _, stack := range a.ServiceControlPolicies {
+	for i, stack := range a.ServiceControlPolicies {
 		acctStackNames := strings.Split(stack.Name, ",")
-		var matchingStackNames []string
 		for _, name := range acctStackNames {
 			for _, targetName := range targetStackNames {
 				if strings.TrimSpace(name) == strings.TrimSpace(targetName) {
-					matchingStackNames = append(matchingStackNames, name)
+					matchingStacks = append(matchingStacks, a.ServiceControlPolicies[i])
 					break
 				}
 			}
 		}
-		if len(matchingStackNames) > 0 {
-			matchingStacks = append(matchingStacks, Stack{
-				Path: stack.Path,
-				Type: stack.Type,
-				Name: strings.Join(matchingStackNames, ","),
-			})
-		}
 	}
+
 	return matchingStacks
 }


### PR DESCRIPTION
- Before when you targeted with `--stack=` and a terraform workspace was set then we would remove the Workspace setting. This now preserves the stacks settings through
- Preserve file mode when copying over. This would allow someone to set the provider in the `Stack` path and then reuse it when copied over to `telophasedirs`
- Add an error message if using a role that doesn't have access to the organizations API. This was failing before with an AccessDenied and not obvious to an end user