### PR TITLE
AssumeRoleName on stacks

### DIFF
--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -103,7 +103,7 @@ Stacks:
   - Path:  # (Required) Path to CDK or Terraform project. This must be a directory.
     Type:  # (Required) "CDK" or "Terraform".
     Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
-    RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
+    AssumeRoleName:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName` which is typically the `OrganizationAccountAccessRole`.
     Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use.
 ```

--- a/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
+++ b/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
@@ -45,7 +45,7 @@ Stacks:
   - Path:  # (Required) Path to CDK or Terraform project. This must be a directory.
     Type:  # (Required) "CDK" or "Terraform".
     Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
-    RoleOverrideARN:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName`.
+    AssumeRoleName:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName` which is typically the `OrganizationAccountAccessRole`.
     Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use. 
 ```

--- a/resource/stack.go
+++ b/resource/stack.go
@@ -1,27 +1,41 @@
 package resource
 
 import (
+	"fmt"
+
 	"github.com/samsarahq/go/oops"
 )
 
 type Stack struct {
-	Name            string `yaml:"Name"`
-	Type            string `yaml:"Type"`
-	Path            string `yaml:"Path"`
-	Region          string `yaml:"Region,omitempty"`
-	RoleOverrideARN string `yaml:"RoleOverrideARN,omitempty"`
-	Workspace       string `yaml:"Workspace,omitempty"`
+	// When adding a new type to the struct, make sure you add it to the `NewForRegion` method.
+	Name                      string `yaml:"Name"`
+	Type                      string `yaml:"Type"`
+	Path                      string `yaml:"Path"`
+	Region                    string `yaml:"Region,omitempty"`
+	RoleOverrideARNDeprecated string `yaml:"RoleOverrideARN,omitempty"` // Deprecated
+	AssumeRoleName            string `yaml:"AssumeRoleName,omitempty"`
+	Workspace                 string `yaml:"Workspace,omitempty"`
 }
 
 func (s Stack) NewForRegion(region string) Stack {
 	return Stack{
-		Name:            s.Name,
-		Type:            s.Type,
-		Path:            s.Path,
-		Region:          region,
-		RoleOverrideARN: s.RoleOverrideARN,
-		Workspace:       s.Workspace,
+		Name:                      s.Name,
+		Type:                      s.Type,
+		Path:                      s.Path,
+		Region:                    region,
+		RoleOverrideARNDeprecated: s.RoleOverrideARNDeprecated,
+		AssumeRoleName:            s.AssumeRoleName,
+		Workspace:                 s.Workspace,
 	}
+}
+
+func (s Stack) RoleARN(acct Account) *string {
+	if s.AssumeRoleName != "" {
+		result := fmt.Sprintf("arn:aws:iam::%s:role/%s", acct.AccountID, s.AssumeRoleName)
+		return &result
+	}
+
+	return nil
 }
 
 func (s Stack) AWSRegionEnv() *string {

--- a/resource/stack_test.go
+++ b/resource/stack_test.go
@@ -1,0 +1,43 @@
+package resource
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// TestNewForRegion ensures NewForRegion has an exact replica of the Stack type
+// when creating a new Stack. This makes sure that we don't add a field to the
+// Stack struct that doesn't get copied over.
+func TestNewForRegion(t *testing.T) {
+	newStack := Stack{}
+	setFields(&newStack)
+	newStack.Region = "us-west-2"
+
+	valS := reflect.ValueOf(&newStack).Elem()
+	valNewS := reflect.ValueOf(&newStack).Elem()
+
+	for i := 0; i < valS.NumField(); i++ {
+		valNewS.Field(i).Set(valS.Field(i))
+	}
+
+	newStackSameRegion := newStack.NewForRegion("us-west-2")
+
+	assert.True(t, reflect.DeepEqual(newStack, newStackSameRegion), "you likely added something to the Stack struct wihtout adding it to the stack in NewForRegion")
+}
+
+func setFields(s *Stack) {
+	v := reflect.ValueOf(s).Elem()
+	for i := 0; i < v.NumField(); i++ {
+		field := v.Field(i)
+		switch field.Kind() {
+		case reflect.String:
+			// all strings set as an example value
+			field.SetString("example value for " + v.Type().Field(i).Name)
+		case reflect.Int:
+			// all ints are set to 8
+			field.SetInt(8)
+		}
+	}
+}

--- a/resourceoperation/cdk.go
+++ b/resourceoperation/cdk.go
@@ -58,8 +58,8 @@ func (co *cdkOperation) Call(ctx context.Context) error {
 	}
 
 	// We use the stack role if it set after we have bootstrapped.
-	if co.Stack.RoleOverrideARN != "" {
-		opRole, _, err = authAWS(*co.Account, co.Stack.RoleOverrideARN, co.OutputUI)
+	if roleArn := co.Stack.RoleARN(*co.Account); roleArn != nil {
+		opRole, _, err = authAWS(*co.Account, *roleArn, co.OutputUI)
 		if err != nil {
 			return err
 		}

--- a/resourceoperation/terraform.go
+++ b/resourceoperation/terraform.go
@@ -48,8 +48,8 @@ func (to *tfOperation) Call(ctx context.Context) error {
 	var stackRole *sts.AssumeRoleOutput
 	var assumeRoleErr error
 	if to.Account.AccountID != "" {
-		if to.Stack.RoleOverrideARN != "" {
-			stackRole, _, assumeRoleErr = authAWS(*to.Account, to.Stack.RoleOverrideARN, to.OutputUI)
+		if roleArn := to.Stack.RoleARN(*to.Account); roleArn != nil {
+			stackRole, _, assumeRoleErr = authAWS(*to.Account, *roleArn, to.OutputUI)
 		} else {
 			stackRole, _, assumeRoleErr = authAWS(*to.Account, to.Account.AssumeRoleARN(), to.OutputUI)
 		}


### PR DESCRIPTION
Use AssumeRoleName instead of AssumeRoleARN because we will be able to generate
the ARN based on what account the stack is applied to.

