### PR TITLE
resourceop: deploy all CDK stacks by default

### DIFF
--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -102,7 +102,7 @@ CDK and Terraform stacks can be assigned to `Account`s and `OrganizationUnits`s.
 Stacks:
   - Path:  # (Required) Path to CDK or Terraform project. This must be a directory.
     Type:  # (Required) "CDK" or "Terraform".
-    Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
+    Name:  # (Optional) Name of the Stack to filter on with --stacks.
     AssumeRoleName:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName` which is typically the `OrganizationAccountAccessRole`.
     Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use.

--- a/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
+++ b/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
@@ -44,7 +44,7 @@ CDK and Terraform stacks can be assigned to `Account`s and `OrganizationUnits`s.
 Stacks:
   - Path:  # (Required) Path to CDK or Terraform project. This must be a directory.
     Type:  # (Required) "CDK" or "Terraform".
-    Name:  # (Optional) Apply only CDK stack with this name. By default, all CDK stacks are applied. (CDK Only)
+    Name:  # (Optional) Name of the Stack to filter on with --stacks.
     AssumeRoleName:  # (Optional) Force CDK and Terraform to us a specific role when applying a stack. The default role is the account's `AssumeRoleName` which is typically the `OrganizationAccountAccessRole`.
     Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use. 

--- a/resourceoperation/cdk.go
+++ b/resourceoperation/cdk.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -80,11 +79,9 @@ func (co *cdkOperation) Call(ctx context.Context) error {
 	}
 
 	cdkArgs = append(cdkArgs, cdkDefaultArgs(*co.Account, co.Stack)...)
-	if co.Stack.Name == "" {
-		cdkArgs = append(cdkArgs, "--all")
-	} else {
-		cdkArgs = append(cdkArgs, strings.Split(co.Stack.Name, ",")...)
-	}
+	// Deploy all CDK stacks every time.
+	cdkArgs = append(cdkArgs, "--all")
+
 	cmd := exec.Command(localstack.CdkCmd(), cdkArgs...)
 	cmd.Dir = co.Stack.Path
 	if opRole != nil {
@@ -139,10 +136,6 @@ func synthCDK(result *sts.AssumeRoleOutput, acct resource.Account, stack resourc
 		[]string{"synth"},
 		cdkDefaultArgs(acct, stack)...,
 	)
-
-	if stack.Name != "" {
-		cdkArgs = append(cdkArgs, strings.Split(stack.Name, ",")...)
-	}
 
 	cmd := exec.Command(localstack.CdkCmd(), cdkArgs...)
 	cmd.Dir = stack.Path


### PR DESCRIPTION
The `Name` within `Stacks` go struct has caused confusion so we default to deploying all CDK stacks so that the Name can be used alongside terraform stacks and filter.

The original intention of `Name` was to be able to target CDK stacks, but we want to provide filtering on terraform and cdk stacks. We can always add back CDK stack filtering by allowing an end user to pass in additional flags to the CDK or specifying CDKStacks. For now, we are removing the feature