### PR TITLE
ymlparser: remove orgv2 suffix

### DIFF
--- a/cmd/provisionaccounts.go
+++ b/cmd/provisionaccounts.go
@@ -73,12 +73,12 @@ func processOrg(consoleUI runner.ConsoleUI, cmd string) {
 			return
 		}
 		consoleUI.Print("Importing AWS Organization", *mgmtAcct)
-		if err := importOrgV2(ctx, consoleUI, orgClient, mgmtAcct); err != nil {
+		if err := importOrg(ctx, consoleUI, orgClient, mgmtAcct); err != nil {
 			consoleUI.Print(fmt.Sprintf("error importing organization: %s", err), *mgmtAcct)
 		}
 	}
 
-	rootAWSOU, err := ymlparser.NewParser(orgClient).ParseOrganizationV2(ctx, orgFile)
+	rootAWSOU, err := ymlparser.NewParser(orgClient).ParseOrganization(ctx, orgFile)
 	if err != nil {
 		consoleUI.Print(fmt.Sprintf("error parsing organization: %s", err), resource.Account{AccountID: "error", AccountName: "error"})
 	}
@@ -126,7 +126,7 @@ func processOrg(consoleUI runner.ConsoleUI, cmd string) {
 	consoleUI.Print("Done.\n", *mgmtAcct)
 }
 
-func importOrgV2(ctx context.Context, consoleUI runner.ConsoleUI, orgClient awsorgs.Client, mgmtAcct *resource.Account) error {
+func importOrg(ctx context.Context, consoleUI runner.ConsoleUI, orgClient awsorgs.Client, mgmtAcct *resource.Account) error {
 
 	rootId, err := orgClient.GetRootId()
 	if err != nil {
@@ -146,7 +146,7 @@ func importOrgV2(ctx context.Context, consoleUI runner.ConsoleUI, orgClient awso
 		Accounts: rootOU.Accounts,
 	}
 
-	if err := ymlparser.WriteOrgV2File(orgFile, &org); err != nil {
+	if err := ymlparser.WriteOrgFile(orgFile, &org); err != nil {
 		return err
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,7 +38,7 @@ func Execute() {
 func ProcessOrgEndToEnd(consoleUI runner.ConsoleUI, cmd int, targets []string) {
 	ctx := context.Background()
 	orgClient := awsorgs.New()
-	rootAWSOU, err := ymlparser.NewParser(orgClient).ParseOrganizationV2(ctx, orgFile)
+	rootAWSOU, err := ymlparser.NewParser(orgClient).ParseOrganization(ctx, orgFile)
 	if err != nil {
 		consoleUI.Print(fmt.Sprintf("error: %s", err), resource.Account{AccountID: "error", AccountName: "error"})
 		return

--- a/lib/ymlparser/organization.go
+++ b/lib/ymlparser/organization.go
@@ -28,7 +28,7 @@ func NewParser(orgClient awsorgs.Client) Parser {
 	}
 }
 
-func (o Parser) ParseOrganizationV2(ctx context.Context, filepath string) (*resource.OrganizationUnit, error) {
+func (o Parser) ParseOrganization(ctx context.Context, filepath string) (*resource.OrganizationUnit, error) {
 	if filepath == "" {
 		return nil, errors.New("filepath is empty")
 	}
@@ -44,7 +44,7 @@ func (o Parser) ParseOrganizationV2(ctx context.Context, filepath string) (*reso
 		return nil, err
 	}
 
-	if err := validOrganizationV2(org.Organization); err != nil {
+	if err := validOrganization(org.Organization); err != nil {
 		return nil, err
 	}
 
@@ -150,7 +150,7 @@ func hydrateOUParent(parsedOU *resource.OrganizationUnit) {
 	}
 }
 
-func WriteOrgV2File(filepath string, org *resource.OrganizationUnit) error {
+func WriteOrgFile(filepath string, org *resource.OrganizationUnit) error {
 	orgData := orgDatav2{
 		Organization: *org,
 	}
@@ -170,7 +170,7 @@ func WriteOrgV2File(filepath string, org *resource.OrganizationUnit) error {
 	return nil
 }
 
-func validOrganizationV2(data resource.OrganizationUnit) error {
+func validOrganization(data resource.OrganizationUnit) error {
 	accountEmails := map[string]struct{}{}
 
 	validStates := []string{"delete", ""}

--- a/tests/end2end_test.go
+++ b/tests/end2end_test.go
@@ -966,7 +966,7 @@ func TestEndToEnd(t *testing.T) {
 		err = ioutil.WriteFile("organization.yml", []byte(test.OrgYaml), 0644)
 		assert.NoError(t, err, "Failed to write organization.yml")
 
-		parsedOrg, err := ymlparser.NewParser(orgClient).ParseOrganizationV2(ctx, "organization.yml")
+		parsedOrg, err := ymlparser.NewParser(orgClient).ParseOrganization(ctx, "organization.yml")
 		assert.NoError(t, err, "Failed to parse organization.yml")
 
 		compareOrganizationUnits(t, test.ParseExpected, parsedOrg, false)


### PR DESCRIPTION
We no longer parse the orgv1 so lets remove all v2 references