### PR TITLE
*: support OU and account AWS Tags

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/samsarahq/go/oops"
 	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/lib/awsorgs"
 	"github.com/santiago-labs/telophasecli/lib/metrics"
@@ -162,7 +163,7 @@ func resolveMgmtAcct(
 
 	fetchedMgmtAcct, err := orgClient.FetchManagementAccount(ctx)
 	if err != nil {
-		return nil, err
+		return nil, oops.Wrapf(err, "FetchManagementAccount")
 	}
 	return fetchedMgmtAcct, nil
 }

--- a/mintlifydocs/commands/deploy.mdx
+++ b/mintlifydocs/commands/deploy.mdx
@@ -37,7 +37,7 @@ Organization:
             Name: "Default IAM Roles for CI"
         # Tags are specified here
         Tags:
-          - "production"
+          - "env=production"
         Accounts:
           - Email: production+us0@example.com
             AccountName: US0 
@@ -64,6 +64,6 @@ Organization:
 ```
 ## Using Tags
 
-Running `telophasecli deploy --tag=production` will only deploy terraform and CDK changes for the accounts named `US0`, `US1`, `US2`, `US3`. The resulting TUI looks like:
+Running `telophasecli deploy --tag="env=production"` will only deploy terraform and CDK changes for the accounts named `US0`, `US1`, `US2`, `US3`. The resulting TUI looks like:
 
 <img src="/images/tui-tags.png" style={{ borderRadius: '0.5rem' }} />

--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -45,7 +45,7 @@ Organization:
 Accounts:
   - Email:  # (Required) Email used to create the account. This will be the root user for this account.
     AccountName:  # (Required) Name of the account.
-    Tags:  # (Optional) Telophase label for this account.
+    Tags:  # (Optional) Telophase label for this account. Tags translate to AWS tags with a `=` as the key value delimiter. For example, `telophase:env=prod`
     Stacks:  # (Optional) CDK or Terraform stacks to apply to all accounts in this Organization Unit.
     State:  # (Optional) Can be set to `deleted` to delete an account. Experimental.
 ```
@@ -126,7 +126,9 @@ This will run two separate applies in the `us-prod` account:
 2. `tf/default-vpc` Terraform stack.
 
 # Tags
-Tags can be used to perform operations on groups of accounts. `Account`s and `OrganizationUnits`s can be tagged. Tags do _not_ represent AWS `Tag`s.
+Tags can be used to perform operations on groups of accounts. `Account`s and `OrganizationUnits`s can be tagged. Tags represent AWS `Tag`s.
+Telophase Tags map to AWS tags with a key, value pair delimited by an `=`. For example, `env=dev` will translate to an AWS tag on an Account or OU with the key `env` and value `dev`.
+
 
 Telophase commands optionally take tags as inputs, allowing you to limit the scope of the operation. 
 
@@ -136,13 +138,12 @@ Telophase commands optionally take tags as inputs, allowing you to limit the sco
     - Email: newdev+1@telophase.dev
       AccountName: newdev1
       Tags:
-        - "dev"
+        - "env=dev"
     - Email: newdev+2@telophase.dev
       AccountName: newdev2
-      Tags:
-        - "dev"
+
     - Email: production@telophase.dev
       AccountName: production
 ```
 
-`telophasecli diff --tag dev` will show a `diff` for `newdev1` and `newdev2` accounts only.
+`telophasecli diff --tag "env=dev"` will show a `diff` for only the `newdev1` account.

--- a/resource/organization_unit.go
+++ b/resource/organization_unit.go
@@ -6,6 +6,7 @@ type OrganizationUnit struct {
 	ChildGroups            []*OrganizationUnit `yaml:"AccountGroups,omitempty"` // Deprecated. Use `OrganizationUnits`
 	ChildOUs               []*OrganizationUnit `yaml:"OrganizationUnits,omitempty"`
 	Tags                   []string            `yaml:"Tags,omitempty"`
+	AWSTags                []string            `yaml:"-"`
 	Accounts               []*Account          `yaml:"Accounts,omitempty"`
 	BaselineStacks         []Stack             `yaml:"Stacks,omitempty"`
 	ServiceControlPolicies []Stack             `yaml:"ServiceControlPolicies,omitempty"`
@@ -32,6 +33,15 @@ func (grp OrganizationUnit) AllTags() []string {
 	tags = append(tags, grp.Tags...)
 	if grp.Parent != nil {
 		tags = append(tags, grp.Parent.AllTags()...)
+	}
+	return tags
+}
+
+func (grp OrganizationUnit) AllAWSTags() []string {
+	var tags []string
+	tags = append(tags, grp.AWSTags...)
+	if grp.Parent != nil {
+		tags = append(tags, grp.Parent.AllAWSTags()...)
 	}
 	return tags
 }

--- a/resourceoperation/interface.go
+++ b/resourceoperation/interface.go
@@ -9,6 +9,7 @@ const (
 	UpdateParent = 1
 	Create       = 2
 	Update       = 3
+	UpdateTags   = 6
 
 	// IaC
 	Diff   = 4


### PR DESCRIPTION
This PR supports tagging at the OU and Account level. You can now:
- Tag resources in telophase and result in tagging within AWS via an `=` delimited string. - For example, `env=prod` will create a tag with key `env` and value `prod` - If there is no `=` then the value will be empty on the AWS tag.

- Account tags will inherit tags from their OU parent tree