### PR TITLE
cmd: exit 1 if cdk, cloudformation or terraform fail

### DIFF
--- a/cmd/iac.go
+++ b/cmd/iac.go
@@ -16,8 +16,11 @@ func runIAC(
 	consoleUI runner.ConsoleUI,
 	cmd int,
 	accts []resource.Account,
-) {
+) error {
 	var wg sync.WaitGroup
+
+	var once sync.Once
+	var retError error
 
 	for i := range accts {
 		wg.Add(1)
@@ -40,6 +43,9 @@ func runIAC(
 
 			for _, op := range ops {
 				if err := op.Call(ctx); err != nil {
+					once.Do(func() {
+						retError = err
+					})
 					consoleUI.Print(fmt.Sprintf("%v", err), acct)
 					return
 				}
@@ -48,6 +54,8 @@ func runIAC(
 	}
 
 	wg.Wait()
+
+	return retError
 }
 func contains(e string, s []string) bool {
 	for _, a := range s {

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/samsarahq/go/oops v0.0.0-20220211150445-4b291d6feac4
 	github.com/spf13/cobra v1.7.0
 	github.com/stretchr/testify v1.8.4
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	gopkg.in/yaml.v3 v3.0.1
 )
 

--- a/go.sum
+++ b/go.sum
@@ -66,6 +66,7 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug
 golang.org/x/net v0.1.0 h1:hZ/3BUoy5aId7sCpA/Tc5lt8DkFgdVS2onTpJsZ/fl0=
 golang.org/x/net v0.1.0/go.mod h1:Cx3nUiGt4eDBEyega/BKRp+/AlGL8hYe7U9odMt2Cco=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=


### PR DESCRIPTION
If the diff or deploy fail then we want to ensure that telophase exits with a non-zero status code.

This makes it easier to use in a script with set -e to show up as red when telophasecli is used in CI