### PR TITLE
Support CloudformationCapabilities for Stacks

### DIFF
--- a/examples/cloudformation/iam/role.yml
+++ b/examples/cloudformation/iam/role.yml
@@ -1,0 +1,23 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Description: Administrator access service role for CloudFormation 
+Resources:
+  CFNAdminRole:
+    Type: "AWS::IAM::Role"
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+        - Effect: "Allow"
+          Principal:
+            Service: ["cloudformation.amazonaws.com"]
+          Action: "sts:AssumeRole"
+      Path: "/"
+      ManagedPolicyArns:
+        - 'arn:aws:iam::aws:policy/AdministratorAccess'
+Outputs:
+  CFNAdminRole:
+    Description: CloudFormation admin access service role.
+    Value: !Ref CFNAdminRole
+  CFNAdminRoleArn:
+    Description: CloudFormation admin access service role ARN.
+    Value: !GetAtt CFNAdminRole.Arn  

--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -107,6 +107,7 @@ Stacks:
     Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use.
     CloudformationParameters: # (Optional) A list of parameters to pass into the cloudformation stack.
+    CloudformationCapabilities: # (Optional) A list of capabilities to pass into the cloudformation stack the only valid values are (CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND).
 ```
 
 ### Example

--- a/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
+++ b/mintlifydocs/features/Assign-IaC-Blueprints-To-Accounts.mdx
@@ -31,6 +31,8 @@ Organization:
                 CloudformationParameters:
                   - "HashKeyElementName=Painter" 
                   - "TableName=test" 
+                CloudformationCapabilities:
+                  - "CAPABILITY_IAM"
           - Email: safety+ingestion@example.app
             AccountName: Safety Ingestion Team
       - Name: Development
@@ -58,4 +60,5 @@ Stacks:
     Region: # (Optional) What region the stack's resources will be provisioned in. Region can be a comma separated list of regions or "all" to apply to all regions in an account.
     Workspace: # (Optional) Specify a Terraform workspace to use. 
     CloudformationParameters: # (Optional) A list of parameters to pass into the cloudformation stack.
+    CloudformationCapabilities: # (Optional) A list of capabilities to pass into the cloudformation stack the only valid values are (CAPABILITY_IAM | CAPABILITY_NAMED_IAM | CAPABILITY_AUTO_EXPAND).
 ```

--- a/resource/stack_test.go
+++ b/resource/stack_test.go
@@ -78,3 +78,105 @@ func TestCloudformationStackName(t *testing.T) {
 	}
 
 }
+
+func TestValidate(t *testing.T) {
+	tests := []struct {
+		input       Stack
+		description string
+
+		wantErr bool
+	}{
+		{
+			input: Stack{
+				Type:   "Cloudformation",
+				Name:   "name",
+				Path:   "path",
+				Region: "us-west-2",
+			},
+			wantErr: false,
+		},
+		{
+			input: Stack{
+				Type:   "Terraform",
+				Path:   "./path",
+				Region: "us-west-2",
+			},
+			wantErr: false,
+		},
+		{
+			input: Stack{
+				Type:   "CDK",
+				Name:   "@danny",
+				Path:   "./path",
+				Region: "us-west-2",
+			},
+			wantErr: false,
+		},
+		{
+			input: Stack{
+				Type:   "Cloudformation",
+				Name:   "name",
+				Path:   "path",
+				Region: "us-west-2",
+				CloudformationCapabilities: []string{
+					"IAM_CAPABILITY",
+				},
+			},
+			description: "misspelled cloudformation capabilities",
+			wantErr:     true,
+		},
+		{
+			input: Stack{
+				Type:   "Cloudformation",
+				Name:   "name",
+				Path:   "path",
+				Region: "us-west-2",
+				CloudformationCapabilities: []string{
+					"IAM_CAPABILITY",
+				},
+			},
+			description: "misspelled cloudformation capabilities",
+			wantErr:     true,
+		},
+		{
+			input: Stack{
+				Type:   "Cloudformation",
+				Name:   "name",
+				Path:   "path",
+				Region: "us-west-2",
+				CloudformationCapabilities: []string{
+					"CAPABILITY_IAM",
+					"CAPABILITY_NAMED_IAM",
+					"CAPABILITY_AUTO_EXPAND",
+				},
+			},
+			description: "all valid capabilities",
+			wantErr:     false,
+		},
+		{
+			input: Stack{
+				Type:   "Cloudformation",
+				Name:   "name",
+				Path:   "path",
+				Region: "us-west-2",
+				CloudformationCapabilities: []string{
+					"CAPABILITY_IAM",
+					"CAPABILITY_NAMED_IAM",
+					// Misspelled below
+					"CAPABILITY_AUTOO_EXPAND",
+				},
+			},
+			description: "one invalid capability",
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range tests {
+		if tc.wantErr {
+			assert.Error(t, tc.input.Validate())
+		} else {
+			assert.NoError(t, tc.input.Validate())
+		}
+	}
+
+}

--- a/resourceoperation/cloudformation.go
+++ b/resourceoperation/cloudformation.go
@@ -128,6 +128,7 @@ func (co *cloudformationOp) createChangeSet(ctx context.Context) (*cloudformatio
 			ChangeSetName: co.Stack.ChangeSetName(),
 			TemplateBody:  &strTemplate,
 			ChangeSetType: &changeSetType,
+			Capabilities:  co.Stack.CloudformationCapabilitiesArg(),
 		},
 	)
 	if err != nil {


### PR DESCRIPTION
Cloudformation requires setting these capabilities if you are making
certain changes. For example, IAM changes require setting a capability

https://docs.aws.amazon.com/AWSCloudFormation/latest/APIReference/API_CreateStack.html#API_CreateStack_RequestParameters