### PR TITLE
resource: use current user if in management account

### DIFF
--- a/lib/awssts/awssts.go
+++ b/lib/awssts/awssts.go
@@ -3,20 +3,22 @@ package awssts
 import (
 	"strings"
 
+	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/santiago-labs/telophasecli/lib/localstack"
 )
 
-func SetEnviron(currEnv []string,
-	accessKeyID,
-	secretAccessKey,
-	sessionToken string,
+func SetEnvironCreds(currEnv []string,
+	creds *sts.Credentials,
 	awsRegion *string) []string {
 	var newEnv []string
+
 	for _, e := range currEnv {
-		if strings.Contains(e, "AWS_ACCESS_KEY_ID=") ||
-			strings.Contains(e, "AWS_SECRET_ACCESS_KEY=") ||
-			strings.Contains(e, "AWS_SESSION_TOKEN=") {
-			continue
+		if creds != nil {
+			if strings.Contains(e, "AWS_ACCESS_KEY_ID=") ||
+				strings.Contains(e, "AWS_SECRET_ACCESS_KEY=") ||
+				strings.Contains(e, "AWS_SESSION_TOKEN=") {
+				continue
+			}
 		}
 
 		if awsRegion != nil && strings.Contains(e, "AWS_REGION=") {
@@ -26,11 +28,13 @@ func SetEnviron(currEnv []string,
 		newEnv = append(newEnv, e)
 	}
 
-	newEnv = append(newEnv,
-		"AWS_ACCESS_KEY_ID="+accessKeyID,
-		"AWS_SECRET_ACCESS_KEY="+secretAccessKey,
-		"AWS_SESSION_TOKEN="+sessionToken,
-	)
+	if creds != nil {
+		newEnv = append(newEnv,
+			"AWS_ACCESS_KEY_ID="+*creds.AccessKeyId,
+			"AWS_SECRET_ACCESS_KEY="+*creds.SecretAccessKey,
+			"AWS_SESSION_TOKEN="+*creds.SessionToken,
+		)
+	}
 
 	if awsRegion != nil {
 		newEnv = append(newEnv, *awsRegion)

--- a/resourceoperation/cdk.go
+++ b/resourceoperation/cdk.go
@@ -9,6 +9,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
+	"github.com/samsarahq/go/oops"
 	"github.com/santiago-labs/telophasecli/cmd/runner"
 	"github.com/santiago-labs/telophasecli/lib/awssess"
 	"github.com/santiago-labs/telophasecli/lib/awssts"
@@ -45,18 +46,18 @@ func (co *cdkOperation) ListDependents() []ResourceOperation {
 func (co *cdkOperation) Call(ctx context.Context) error {
 	co.OutputUI.Print(fmt.Sprintf("Executing CDK stack in %s", co.Stack.Path), *co.Account)
 
-	opRole, region, err := authAWS(*co.Account, *co.Stack.RoleARN(*co.Account), co.OutputUI)
+	creds, region, err := authAWS(*co.Account, *co.Stack.RoleARN(*co.Account), co.OutputUI)
 	if err != nil {
 		return err
 	}
 
 	// We must bootstrap cdk with the account role.
-	bootstrapCDK := bootstrapCDK(opRole, region, *co.Account, co.Stack)
+	bootstrapCDK := bootstrapCDK(creds, region, *co.Account, co.Stack)
 	if err := co.OutputUI.RunCmd(bootstrapCDK, *co.Account); err != nil {
 		return err
 	}
 
-	synthCDK := synthCDK(opRole, *co.Account, co.Stack)
+	synthCDK := synthCDK(creds, *co.Account, co.Stack)
 	if err := co.OutputUI.RunCmd(synthCDK, *co.Account); err != nil {
 		return err
 	}
@@ -76,14 +77,10 @@ func (co *cdkOperation) Call(ctx context.Context) error {
 
 	cmd := exec.Command(localstack.CdkCmd(), cdkArgs...)
 	cmd.Dir = co.Stack.Path
-	if opRole != nil {
-		cmd.Env = awssts.SetEnviron(os.Environ(),
-			*opRole.Credentials.AccessKeyId,
-			*opRole.Credentials.SecretAccessKey,
-			*opRole.Credentials.SessionToken,
-			co.Stack.AWSRegionEnv(),
-		)
-	}
+	cmd.Env = awssts.SetEnvironCreds(os.Environ(),
+		creds,
+		co.Stack.AWSRegionEnv(),
+	)
 	if err := co.OutputUI.RunCmd(cmd, *co.Account); err != nil {
 		return err
 	}
@@ -101,7 +98,7 @@ func (co *cdkOperation) ToString() string {
 	return ""
 }
 
-func bootstrapCDK(result *sts.AssumeRoleOutput, region string, acct resource.Account, stack resource.Stack) *exec.Cmd {
+func bootstrapCDK(creds *sts.Credentials, region string, acct resource.Account, stack resource.Stack) *exec.Cmd {
 	cdkArgs := append([]string{
 		"bootstrap",
 		fmt.Sprintf("aws://%s/%s", acct.AccountID, region),
@@ -111,19 +108,15 @@ func bootstrapCDK(result *sts.AssumeRoleOutput, region string, acct resource.Acc
 
 	cmd := exec.Command(localstack.CdkCmd(), cdkArgs...)
 	cmd.Dir = stack.Path
-	if result != nil {
-		cmd.Env = awssts.SetEnviron(os.Environ(),
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-			stack.AWSRegionEnv(),
-		)
-	}
+	cmd.Env = awssts.SetEnvironCreds(os.Environ(),
+		creds,
+		stack.AWSRegionEnv(),
+	)
 
 	return cmd
 }
 
-func synthCDK(result *sts.AssumeRoleOutput, acct resource.Account, stack resource.Stack) *exec.Cmd {
+func synthCDK(creds *sts.Credentials, acct resource.Account, stack resource.Stack) *exec.Cmd {
 	cdkArgs := append(
 		[]string{"synth"},
 		cdkDefaultArgs(acct, stack)...,
@@ -131,19 +124,15 @@ func synthCDK(result *sts.AssumeRoleOutput, acct resource.Account, stack resourc
 
 	cmd := exec.Command(localstack.CdkCmd(), cdkArgs...)
 	cmd.Dir = stack.Path
-	if result != nil {
-		cmd.Env = awssts.SetEnviron(os.Environ(),
-			*result.Credentials.AccessKeyId,
-			*result.Credentials.SecretAccessKey,
-			*result.Credentials.SessionToken,
-			stack.AWSRegionEnv(),
-		)
-	}
+	cmd.Env = awssts.SetEnvironCreds(os.Environ(),
+		creds,
+		stack.AWSRegionEnv(),
+	)
 
 	return cmd
 }
 
-func authAWS(acct resource.Account, arn string, consoleUI runner.ConsoleUI) (*sts.AssumeRoleOutput, string, error) {
+func authAWS(acct resource.Account, arn string, consoleUI runner.ConsoleUI) (*sts.Credentials, string, error) {
 	var svc *sts.STS
 	sess := session.Must(awssess.DefaultSession())
 	svc = sts.New(sess)
@@ -155,7 +144,21 @@ func authAWS(acct resource.Account, arn string, consoleUI runner.ConsoleUI) (*st
 	}
 
 	role, err := awssess.AssumeRole(svc, input)
-	return role, *sess.Config.Region, err
+	if err != nil {
+		// If we are in the management account the OrganizationAccountAccessRole
+		// does not exist so fallback to the current credentials.
+		if acct.ManagementAccount {
+			// I tried to use GetSessionToken to satisfy a type and avoid
+			// passing around a nil. However, GetSessionToken's output keys are
+			// not allowed to make any IAM changes.
+			//
+			// Return nil because we don't need to assume a role.
+			return nil, "us-east-1", nil
+		}
+
+		return nil, "", oops.Wrapf(err, "AssumeRole")
+	}
+	return role.Credentials, *sess.Config.Region, nil
 }
 
 func cdkDefaultArgs(acct resource.Account, stack resource.Stack) []string {

--- a/resourceoperation/cloudformation.go
+++ b/resourceoperation/cloudformation.go
@@ -194,7 +194,7 @@ func (co *cloudformationOp) executeChangeSet(ctx context.Context, changeSetID *s
 			return cs, nil
 
 		case cloudformation.ExecutionStatusExecuteFailed:
-			co.OutputUI.Print(fmt.Sprintf("Failed to execute change set: (%s) for path: %s", *co.Stack.CloudformationStackName(), co.Stack.Path), *co.Account)
+			co.OutputUI.Print(fmt.Sprintf("Failed to execute change set: (%s) for path: %s Reason: %s", *co.Stack.CloudformationStackName(), co.Stack.Path, *cs.StatusReason), *co.Account)
 			return cs, oops.Errorf("ExecuteChangeSet failed")
 		}
 


### PR DESCRIPTION
In the management account if we try to assume the
OrganizationAccountAccessRole and fail we should use the default
credentials and assume they are in the management account.

The OrganizationAccountAccessRole is created by default in child
accounts, but not in the management account.
