### PR TITLE
resourceop cdk: skip assume role if TELOHASE_BYPASS_ASSUME_ROLE is se

### DIFF
--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -394,7 +394,7 @@ func (c Client) CloseAccounts(ctx context.Context, accts []*organizations.Accoun
 func (c Client) GetRootId() (string, error) {
 	rootsOutput, err := c.organizationClient.ListRoots(&organizations.ListRootsInput{})
 	if err != nil {
-		return "", oops.Wrapf(err, "organizaqtions.ListRootsInput, make sure you have access to organizations from this role")
+		return "", oops.Wrapf(err, "organizations.ListRootsInput, make sure you have access to organizations from this role")
 	}
 	if len(rootsOutput.Roots) > 0 {
 		return *rootsOutput.Roots[0].Id, nil

--- a/resourceoperation/cdk.go
+++ b/resourceoperation/cdk.go
@@ -137,6 +137,10 @@ func synthCDK(creds *sts.Credentials, acct resource.Account, stack resource.Stac
 }
 
 func authAWS(acct resource.Account, arn string, consoleUI runner.ConsoleUI) (*sts.Credentials, string, error) {
+	if os.Getenv("TELOPHASE_BYPASS_ASSUME_ROLE") != "" {
+		return nil, "us-east-1", nil
+	}
+
 	var svc *sts.STS
 	sess := session.Must(awssess.DefaultSession())
 	svc = sts.New(sess)


### PR DESCRIPTION
Sometimes people want to assume roles via terraform or CDK and defer to
their local credentials. In this case, let them override it with an
environment variable.