### PR TITLE
Support OUFilepath within an OrganizationUnit

### DIFF
--- a/cmd/provisionaccounts.go
+++ b/cmd/provisionaccounts.go
@@ -63,7 +63,7 @@ var accountProvision = &cobra.Command{
 }
 
 func processOrg(consoleUI runner.ConsoleUI, cmd string) {
-	orgClient := awsorgs.New()
+	orgClient := awsorgs.New(nil)
 	ctx := context.Background()
 
 	if cmd == "import" {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -42,7 +42,7 @@ func setOpsError() error {
 
 func ProcessOrgEndToEnd(consoleUI runner.ConsoleUI, cmd int, targets []string) error {
 	ctx := context.Background()
-	orgClient := awsorgs.New()
+	orgClient := awsorgs.New(nil)
 	rootAWSOU, err := ymlparser.NewParser(orgClient).ParseOrganization(ctx, orgFile)
 	if err != nil {
 		consoleUI.Print(fmt.Sprintf("error: %s", err), resource.Account{AccountID: "error", AccountName: "error"})

--- a/lib/awsorgs/awsorgsmock/organizationmock.go
+++ b/lib/awsorgs/awsorgsmock/organizationmock.go
@@ -1,0 +1,118 @@
+// package awsorgsmock provides a basic mocked implementation of the
+// organizations interface for telophase.
+//
+// The structure fo the mock org is that account 0 is the root account.
+// Account 1 - Child account
+// Account 2 - Another Child account
+// Account 3 - Orphan account within the organization.
+// Other methods are mocked, but don't perform any functions to avoid nil pointer exceptions.
+package awsorgsmock
+
+import (
+	"fmt"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/request"
+	"github.com/aws/aws-sdk-go/service/organizations"
+	"github.com/aws/aws-sdk-go/service/organizations/organizationsiface"
+)
+
+func New() organizationsiface.OrganizationsAPI {
+	return &mockedOrganizations{}
+}
+
+type mockedOrganizations struct {
+	organizationsiface.OrganizationsAPI
+}
+
+// ListAccountsPagesWithContext mocks the ListAccountsPagesWithContext method
+func (m *mockedOrganizations) ListAccountsPagesWithContext(ctx aws.Context, input *organizations.ListAccountsInput, fn func(*organizations.ListAccountsOutput, bool) bool, opts ...request.Option) error {
+	return m.ListAccountsPagesWithContextFunc(ctx, input, fn, opts...)
+}
+
+func mockAccount(index int) *organizations.Account {
+	return &organizations.Account{
+		Id:    aws.String(fmt.Sprintf("%d0000000000", index)),
+		Name:  aws.String(fmt.Sprintf("test%d", index)),
+		Email: aws.String(fmt.Sprintf("test%d@example.com", index)),
+	}
+}
+
+func (m *mockedOrganizations) ListAccountsPagesWithContextFunc(ctx aws.Context, input *organizations.ListAccountsInput, fn func(*organizations.ListAccountsOutput, bool) bool, opts ...request.Option) error {
+	fn(&organizations.ListAccountsOutput{
+		Accounts: []*organizations.Account{
+			mockAccount(0),
+			mockAccount(1),
+			mockAccount(2),
+			mockAccount(3),
+		},
+	}, true)
+
+	return nil
+}
+
+func (m mockedOrganizations) DescribeOrganization(org *organizations.DescribeOrganizationInput) (*organizations.DescribeOrganizationOutput, error) {
+	return &organizations.DescribeOrganizationOutput{
+		Organization: &organizations.Organization{
+			MasterAccountId: mockAccount(0).Id,
+		},
+	}, nil
+}
+
+func (m mockedOrganizations) DescribeOrganizationWithContext(ctx aws.Context, org *organizations.DescribeOrganizationInput, opts ...request.Option) (*organizations.DescribeOrganizationOutput, error) {
+	return &organizations.DescribeOrganizationOutput{
+		Organization: &organizations.Organization{
+			MasterAccountId: mockAccount(0).Id,
+		},
+	}, nil
+}
+
+func (m mockedOrganizations) ListRoots(org *organizations.ListRootsInput) (*organizations.ListRootsOutput, error) {
+	return &organizations.ListRootsOutput{
+		Roots: []*organizations.Root{
+			{
+				Id:   aws.String("r-0000"),
+				Name: aws.String("root"),
+			},
+		},
+	}, nil
+}
+
+func (m *mockedOrganizations) ListAccountsForParentPagesWithContext(ctx aws.Context, input *organizations.ListAccountsForParentInput, fn func(*organizations.ListAccountsForParentOutput, bool) bool, opts ...request.Option) error {
+	return m.ListAccountsForParentPagesWithContextFunc(ctx, input, fn, opts...)
+}
+
+func (m *mockedOrganizations) ListAccountsForParentPagesWithContextFunc(ctx aws.Context, input *organizations.ListAccountsForParentInput, fn func(*organizations.ListAccountsForParentOutput, bool) bool, opts ...request.Option) error {
+	if aws.StringValue(input.ParentId) == "1ou" {
+		fn(&organizations.ListAccountsForParentOutput{
+			Accounts: []*organizations.Account{
+				mockAccount(1),
+				mockAccount(2),
+			},
+		}, true)
+	}
+
+	return nil
+}
+
+func (m *mockedOrganizations) ListOrganizationalUnitsForParentPagesWithContext(ctx aws.Context, input *organizations.ListOrganizationalUnitsForParentInput, fn func(*organizations.ListOrganizationalUnitsForParentOutput, bool) bool, opts ...request.Option) error {
+	return m.ListOrganizationalUnitsForParentPagesWithContextFunc(ctx, input, fn, opts...)
+}
+
+func (m *mockedOrganizations) ListOrganizationalUnitsForParentPagesWithContextFunc(ctx aws.Context, input *organizations.ListOrganizationalUnitsForParentInput, fn func(*organizations.ListOrganizationalUnitsForParentOutput, bool) bool, opts ...request.Option) error {
+	fn(&organizations.ListOrganizationalUnitsForParentOutput{
+		OrganizationalUnits: []*organizations.OrganizationalUnit{},
+	}, true)
+
+	return nil
+}
+
+func (m *mockedOrganizations) ListTagsForResourcePagesWithContext(ctx aws.Context, input *organizations.ListTagsForResourceInput, fn func(*organizations.ListTagsForResourceOutput, bool) bool, opts ...request.Option) error {
+	return m.ListTagsForResourcePagesWithContextFunc(ctx, input, fn, opts...)
+}
+
+func (m *mockedOrganizations) ListTagsForResourcePagesWithContextFunc(ctx aws.Context, input *organizations.ListTagsForResourceInput, fn func(*organizations.ListTagsForResourceOutput, bool) bool, opts ...request.Option) error {
+	fn(&organizations.ListTagsForResourceOutput{}, true)
+
+	return nil
+}

--- a/lib/awsorgs/organization.go
+++ b/lib/awsorgs/organization.go
@@ -22,7 +22,19 @@ type Client struct {
 	organizationClient organizationsiface.OrganizationsAPI
 }
 
-func New() Client {
+type Config struct {
+	OrganizationClient organizationsiface.OrganizationsAPI
+}
+
+func New(cfg *Config) Client {
+	if cfg != nil {
+		if cfg.OrganizationClient != nil {
+			return Client{
+				organizationClient: cfg.OrganizationClient,
+			}
+		}
+	}
+
 	sess := session.Must(awssess.DefaultSession())
 	orgsClient := organizations.New(sess)
 

--- a/lib/ymlparser/organization_test.go
+++ b/lib/ymlparser/organization_test.go
@@ -1,0 +1,104 @@
+package ymlparser
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/santiago-labs/telophasecli/lib/awsorgs"
+	"github.com/santiago-labs/telophasecli/lib/awsorgs/awsorgsmock"
+	"github.com/santiago-labs/telophasecli/resource"
+	"github.com/stretchr/testify/require"
+)
+
+func basicOU() resource.OrganizationUnit {
+	return resource.OrganizationUnit{
+		OUName: "root",
+		OUID:   aws.String("r-0000"),
+		ChildOUs: []*resource.OrganizationUnit{
+			{
+				OUName: "ExampleOU",
+				BaselineStacks: []resource.Stack{
+					{
+						Type: "CDK",
+						Path: "examples/localstack/s3-remote-state",
+						Name: "example",
+					},
+				},
+				Tags: []string{
+					"ou=ExampleTenants",
+				},
+				Accounts: []*resource.Account{
+					{
+						Email:       "test1@example.com",
+						AccountName: "test1",
+						BaselineStacks: []resource.Stack{
+							{
+								Type:   "CDK",
+								Path:   "examples/cdk/sqs",
+								Name:   "example",
+								Region: "us-west-2,us-east-1",
+							},
+						},
+						AccountID: "10000000000",
+					},
+					{
+						Email:       "test2@example.com",
+						AccountName: "test2",
+						AccountID:   "20000000000",
+					},
+				},
+			},
+			{
+				OUName: "ExampleOU2",
+				Accounts: []*resource.Account{
+					{
+						Email:       "test3@example.com",
+						AccountName: "test3",
+						AccountID:   "30000000000",
+					},
+				},
+			},
+		},
+	}
+}
+
+func TestParseOrganization(t *testing.T) {
+	tests := []struct {
+		name    string
+		orgPath string
+		want    resource.OrganizationUnit
+	}{
+		{
+			name:    "basic OU",
+			orgPath: "./testdata/organization-basic.yml",
+			want:    basicOU(),
+		},
+		{
+			name:    "OU with child filepaths",
+			orgPath: "./testdata/organization-with-filepath.yml",
+			want:    basicOU(),
+		},
+	}
+	for _, tc := range tests {
+		mockClient := awsorgs.New(&awsorgs.Config{
+			OrganizationClient: awsorgsmock.New(),
+		})
+
+		parser := NewParser(mockClient)
+
+		actual, err := parser.ParseOrganization(context.Background(), tc.orgPath)
+		require.NoError(t, err)
+		ignoreFields := []cmp.Option{
+			cmpopts.IgnoreFields(resource.OrganizationUnit{}, "Parent"),
+			cmpopts.IgnoreFields(resource.Account{}, "Parent"),
+		}
+
+		if diff := cmp.Diff(tc.want.ChildOUs, actual.ChildOUs, ignoreFields...); diff != "" {
+			t.Errorf(fmt.Sprintf("expected no diff for %s got diff: %+v", tc.name, diff))
+		}
+	}
+}

--- a/lib/ymlparser/testdata/organization-basic.yml
+++ b/lib/ymlparser/testdata/organization-basic.yml
@@ -1,0 +1,27 @@
+Organization:
+  OrganizationUnits:
+    - Name: ExampleOU 
+      Tags:
+        - "ou=ExampleTenants"
+
+      Stacks:
+        - Type: "CDK"
+          Path: "examples/localstack/s3-remote-state"
+          Name: "example"
+
+      Accounts:
+        - Email: test1@example.com
+          AccountName: test1 
+          Stacks:
+          - Type: "CDK"
+            Path: "examples/cdk/sqs"
+            Name: "example"
+            Region: "us-west-2,us-east-1"
+
+        - Email: test2@example.com 
+          AccountName: test2 
+
+    - Name: ExampleOU2
+      Accounts:
+        - Email: test3@example.com 
+          AccountName: test3

--- a/lib/ymlparser/testdata/organization-child.yml
+++ b/lib/ymlparser/testdata/organization-child.yml
@@ -1,0 +1,20 @@
+Name: ExampleOU 
+Tags:
+  - "ou=ExampleTenants"
+
+Stacks:
+  - Type: "CDK"
+    Path: "examples/localstack/s3-remote-state"
+    Name: "example"
+
+Accounts:
+  - Email: test1@example.com
+    AccountName: test1
+    Stacks:
+    - Type: "CDK"
+      Path: "examples/cdk/sqs"
+      Name: "example"
+      Region: "us-west-2,us-east-1"
+
+  - Email: test2@example.com 
+    AccountName: test2 

--- a/lib/ymlparser/testdata/organization-child2.yml
+++ b/lib/ymlparser/testdata/organization-child2.yml
@@ -1,0 +1,5 @@
+Name: ExampleOU2
+
+Accounts:
+  - Email: test3@example.com
+    AccountName: test3

--- a/lib/ymlparser/testdata/organization-with-filepath.yml
+++ b/lib/ymlparser/testdata/organization-with-filepath.yml
@@ -1,0 +1,7 @@
+Organization:
+    Name: root
+
+    OrganizationUnits:
+    # Path needs to be relative to where telophase is run
+      - OUFilepath: "./testdata/organization-child.yml"
+      - OUFilepath: "./testdata/organization-child2.yml"

--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -72,6 +72,7 @@ OrganizationUnits:
     Accounts:  # (Optional) Child accounts of this Organization Unit.
     Stacks:  # (Optional) Terraform, Cloudformation, and CDK stacks to apply to all accounts in this Organization Unit.
     OrganizationUnits:  # (Optional) Child Organization Units of this Organization Unit.
+  - OUFilepath: # (Oprtional) provide a filepath to load a separate OU into telophase.
 ```
 
 ### Example
@@ -118,13 +119,13 @@ Accounts:
     Stacks:
       - Path: go/src/cdk
         Type: CDK
-        Name: restrict-us
+        Name: s3-remote-state 
       - Path: tf/default-vpc
         Type: Terraform
 ```
 
 This will run two separate applies in the `us-prod` account:
-1. `restrict-us` CDK stack in `go/src/cdk`
+1. `s3-remote-state` CDK stack in `go/src/cdk` that stands up an s3 bucket for a terraform remote state.
 2. `tf/default-vpc` Terraform stack.
 
 # Tags

--- a/resource/organization_unit.go
+++ b/resource/organization_unit.go
@@ -11,6 +11,8 @@ type OrganizationUnit struct {
 	BaselineStacks         []Stack             `yaml:"Stacks,omitempty"`
 	ServiceControlPolicies []Stack             `yaml:"ServiceControlPolicies,omitempty"`
 	Parent                 *OrganizationUnit   `yaml:"-"`
+
+	OUFilepath *string `yaml:"OUFilepath,omitempty"`
 }
 
 func (grp OrganizationUnit) ID() string {

--- a/tests/end2end_test.go
+++ b/tests/end2end_test.go
@@ -1034,7 +1034,7 @@ func TestEndToEnd(t *testing.T) {
 		}
 	}()
 
-	orgClient := awsorgs.New()
+	orgClient := awsorgs.New(nil)
 	for _, test := range tests {
 		fmt.Printf("Running test: %s\n", test.Name)
 		setupTest()


### PR DESCRIPTION
Closes: https://github.com/Santiago-Labs/telophasecli/issues/75

This allows users to specify OUs within separate files. For example:
```yml
Organization:
    Name: root

    OrganizationUnits:
    # Path needs to be relative to where telophase is run
      - OUFilepath: "./testdata/organization-child.yml"
      - OUFilepath: "./testdata/organization-child2.yml"
 ```

This can be helpful to clean up the main `organization.yml` and also allows for CODEOWNERS to own their own OUs and account applying