### PR TITLE
resourceop account: allow delegating services to accounts

### DIFF
--- a/mintlifydocs/config/organization.mdx
+++ b/mintlifydocs/config/organization.mdx
@@ -49,6 +49,7 @@ Accounts:
       # If deleting an account you need to pass in --allow-account-delete to telophasecli as a confirmation of the deletion.
     Tags:  # (Optional) Telophase label for this account. Tags translate to AWS tags with a `=` as the key value delimiter. For example, `telophase:env=prod`
     Stacks:  # (Optional) Terraform, Cloudformation and CDK stacks to apply to all accounts in this Organization Unit.
+    DelegatedAdministratorServices: # (Optional) List of delegated service principals for the current account (e.g. config.amazonaws.com)
 ```
 
 ## Example

--- a/resource/account.go
+++ b/resource/account.go
@@ -22,9 +22,10 @@ type Account struct {
 	ServiceControlPolicies []Stack  `yaml:"ServiceControlPolicies,omitempty"`
 	ManagementAccount      bool     `yaml:"-"`
 
-	Delete                 bool              `yaml:"Delete"`
-	DelegatedAdministrator bool              `yaml:"DelegatedAdministrator,omitempty"`
-	Parent                 *OrganizationUnit `yaml:"-"`
+	Delete                         bool              `yaml:"Delete"`
+	DelegatedAdministrator         bool              `yaml:"DelegatedAdministrator,omitempty"`
+	DelegatedAdministratorServices []string          `yaml:"DelegatedAdministratorServices,omitempty"`
+	Parent                         *OrganizationUnit `yaml:"-"`
 
 	Status string `yaml:"-,omitempty"`
 }

--- a/resourceoperation/interface.go
+++ b/resourceoperation/interface.go
@@ -6,11 +6,12 @@ import (
 
 const (
 	// Accounts
-	UpdateParent = 1
-	Create       = 2
-	Update       = 3
-	UpdateTags   = 6
-	Delete       = 7
+	UpdateParent  = 1
+	Create        = 2
+	Update        = 3
+	UpdateTags    = 6
+	Delete        = 7
+	DelegateAdmin = 8
 
 	// IaC
 	Diff   = 4


### PR DESCRIPTION
This allows someone to delegate different service principals to accounts managed in telophase. One example is:

```
    OrganizationUnits:
      - Name: Security
        Accounts:
          - Email: example+audit@example.com
            AccountName: Audit
            DelegatedAdministratorServices:
              - "config.amazonaws.com"
              - "config-multiaccountsetup.amazonaws.com"
```

This will end up calling `register-delegated-admin` with the listed service principals on the account defined.