### PR TITLE
resource account: allow setting NoStackInheritance

### DIFF
--- a/resource/account.go
+++ b/resource/account.go
@@ -19,6 +19,7 @@ type Account struct {
 	Tags                   []string `yaml:"Tags,omitempty"`
 	AWSTags                []string `yaml:"-"`
 	BaselineStacks         []Stack  `yaml:"Stacks,omitempty"`
+	NoStackInheritance     bool     `yaml:"NoStackInheritance,omitempty"`
 	ServiceControlPolicies []Stack  `yaml:"ServiceControlPolicies,omitempty"`
 	ManagementAccount      bool     `yaml:"-"`
 
@@ -109,7 +110,7 @@ func (a Account) CurrentTags() []string {
 
 func (a Account) AllBaselineStacks() ([]Stack, error) {
 	var stacks []Stack
-	if a.Parent != nil {
+	if a.Parent != nil && !a.NoStackInheritance {
 		stacks = append(stacks, a.Parent.AllBaselineStacks()...)
 	}
 

--- a/resource/account_test.go
+++ b/resource/account_test.go
@@ -40,6 +40,19 @@ var (
 				AccountName: "Example2",
 				AccountID:   "2",
 			},
+			{
+				Email:              "mgmt-account@example.com",
+				AccountName:        "mgmt-account",
+				AccountID:          "3",
+				NoStackInheritance: true,
+				BaselineStacks: []resource.Stack{
+					{
+						Name: "mgmt-stack",
+						Type: "Terraform",
+						Path: "tf/mgmt",
+					},
+				},
+			},
 		},
 		ChildOUs: []*resource.OrganizationUnit{
 			{
@@ -160,6 +173,17 @@ func TestAllBaselineStacks(t *testing.T) {
 					Name: "cdk1",
 					Type: "CDK",
 					Path: "cdk/example",
+				},
+			},
+		},
+		{
+			rootOU:             rootOU,
+			targetAccountEmail: "mgmt-account@example.com",
+			wantStacks: []resource.Stack{
+				{
+					Name: "mgmt-stack",
+					Type: "Terraform",
+					Path: "tf/mgmt",
 				},
 			},
 		},


### PR DESCRIPTION
You can now set NoStackInheritance: true for an account. This will make it so that a stack doesn't inherit from the current OU or parent OUs.

The most useful case for this is when you have the management account at the top level and want to declare top level stacks as well to target all sub accounts except the management account.